### PR TITLE
Pin specific commit of neuralpredictors in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,5 @@ torch
 torchaudio
 torchvision
 wandb
+neuralpredictors @ git+https://github.com/sinzlab/neuralpredictors.git@c99491f65d9f263ae1cbafcada528681f37a3967
 


### PR DESCRIPTION
Neuralpredictors has evolved and isn't compatible with this repository anymore, e.g. neuralpredictors.layers.affine.Bias3DLayer doesn't exists on it's current main branch:

- [Openretina-Code](https://github.com/fededagos/open-retina/blob/885030d3b5e3868e8709799d1f353b27de536b63/openretina/hoefling_2022_models.py#L10C1-L10C83) using Bias3DLayer
- [Code in neuralpredictors.layers.affine](https://github.com/sinzlab/neuralpredictors/blob/v0.3.0.pre/neuralpredictors/layers/affine.py)
