### PR TITLE
Load model using torch.load

### DIFF
--- a/openretina/training.py
+++ b/openretina/training.py
@@ -195,9 +195,7 @@ def save_checkpoint(model, optimizer, epoch, loss, save_folder: str, model_name:
 
 
 def save_model(model: torch.nn.Module, save_folder: str, model_name: str) -> None:
-    if not os.path.exists(save_folder):
-        # only create the lower level directory if it does not exist
-        os.mkdir(save_folder)
+    os.makedirs(save_folder, exist_ok=True)
     date = datetime.datetime.now().strftime("%Y-%m-%d")
     torch.save(model.state_dict(), os.path.join(save_folder, f"{model_name}_{date}_model_weights.pt"))
     torch.save(model, os.path.join(save_folder, f"{model_name}_{date}_model.pt"))

--- a/scripts/hoefling_2022_train.py
+++ b/scripts/hoefling_2022_train.py
@@ -30,7 +30,8 @@ def parse_args():
 
     parser.add_argument("--data_folder", type=str, help="Path to the base data folder", default="/Data/fd_export")
     parser.add_argument("--save_folder", type=str, help="Path were to save outputs", default=".")
-    parser.add_argument("--device", type=str, choices=["cuda", "cpu"], default="cuda")
+    parser.add_argument("--device", type=str, choices=["cuda", "cpu"],
+                        default="cuda" if torch.cuda.is_available() else "cpu")
     parser.add_argument(
         "--datasets",
         type=str,

--- a/scripts/test_os_ds.py
+++ b/scripts/test_os_ds.py
@@ -17,7 +17,8 @@ def parse_args():
 
     parser.add_argument("--model_path", type=str,
                         required=True, help="Path to the saved model")
-    parser.add_argument("--device", choices=["cpu", "cuda"], default="cuda")
+    parser.add_argument("--device", choices=["cpu", "cuda"],
+                        default="cuda" if torch.cuda.is_available() else "cpu")
     parser.add_argument("--data_folder", type=str, default=None,
                         help="Path to the base data folder")
 

--- a/scripts/train_sparse_autoencoder.py
+++ b/scripts/train_sparse_autoencoder.py
@@ -32,7 +32,8 @@ def parse_args():
     parser.add_argument("--data_folder", type=str, help="Path to the base data folder",
                         default="/Data/fd_export")
     parser.add_argument("--save_folder", type=str, help="Path were to save outputs", default=".")
-    parser.add_argument("--device", type=str, choices=["cuda", "cpu"], default="cuda")
+    parser.add_argument("--device", type=str, choices=["cuda", "cpu"],
+                        default="cuda" if torch.cuda.is_available() else "cpu")
     parser.add_argument("--sparsity_factor", type=float, default=0.1)
     parser.add_argument("--hidden_dim", type=int, default=1000, help="Hidden dim for autoencoder")
     parser.add_argument(


### PR DESCRIPTION
We already save the model with torch.save such that we can later-on use torch.load to load it: 
https://github.com/open-retina/open-retina/blob/129034a87825b3ad9202442592c6026da2d7ed8e/openretina/training.py#L203 

I additionally changed to default argparse value for device to dynamically figure out whether to use "cuda" or "cpu".