### PR TITLE
Update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,21 @@
 IPython
 jaxtyping
 matplotlib
-numpy
+numpy<2.0  # h5py loading does not work with 2.0
 pandas
 seaborn
 scipy
+tensorboard
 torch
 torchaudio
 torchvision
 lightning
 wandb
+<<<<<<< Updated upstream
+=======
+hydra-core
+h5py
+>>>>>>> Stashed changes
 # Type Checks
 ruff
 mypy>=1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,11 +11,7 @@ torchaudio
 torchvision
 lightning
 wandb
-<<<<<<< Updated upstream
-=======
-hydra-core
 h5py
->>>>>>> Stashed changes
 # Type Checks
 ruff
 mypy>=1.0


### PR DESCRIPTION
- h5py was not installed by default but we use it
- When using numpy>=2.0 I ran into the following error when loading h5py data:
```
/home/tzenkel/GitRepos/open-retina/openretina/hoefling_2024/data_io.py:110: RuntimeWarning: overflow encountered in scalar multiply
  :, clip_idx * clip_length: (clip_idx + 1) * clip_length, ...
Error executing job with overrides: ['data_folder=/home/tzenkel/Data/TP12']
Traceback (most recent call last):
  File "/home/tzenkel/GitRepos/open-retina/./scripts/train_core_readout.py", line 32, in main
    dataloaders = natmov_dataloaders_v2(data_dict, movies_dictionary=movies_dict, train_chunk_size=100, seed=1000)
  File "/home/tzenkel/GitRepos/open-retina/openretina/hoefling_2024/data_io.py", line 194, in natmov_dataloaders_v2
    movies = get_all_movie_combinations(
  File "/home/tzenkel/GitRepos/open-retina/openretina/hoefling_2024/data_io.py", line 109, in get_all_movie_combinations
    reordered_movie[:, k * clip_length: (k + 1) * clip_length, ...] = movie_train[
RuntimeError: The expanded size of the tensor (150) must match the existing size (0) at non-singleton dimension 1.  Target sizes: [2, 150, 18, 16].  Tensor sizes: [2, 0, 18, 16]
```