### PR TITLE
Small bugfix (dataloader)

### DIFF
--- a/openretina/neuron_data_io.py
+++ b/openretina/neuron_data_io.py
@@ -253,6 +253,7 @@ class NeuronData:
         self.num_clips = num_clips
         self.random_sequences = random_sequences if random_sequences is not None else np.array([])
         self.use_base_sequence = use_base_sequence
+        self.val_clip_idx = val_clip_idx
 
     # this has to become a regular method in the future!
     @property

--- a/scripts/train_core_readout.py
+++ b/scripts/train_core_readout.py
@@ -24,7 +24,7 @@ def main(conf: DictConfig) -> None:
     with open(movies_path, "rb") as f:
         movies_dict = pickle.load(f)
 
-    data_path_responses = os.path.join(data_folder, "2024-03-28_neuron_data_responses_484c12d_djimaging.h5")
+    data_path_responses = os.path.join(data_folder, "2024-08-14_neuron_data_responses_484c12d_djimaging.h5")
     responses = load_h5_into_dict(data_path_responses)
 
     data_dict = make_final_responses(responses, response_type="natural")  # type: ignore


### PR DESCRIPTION
https://github.com/open-retina/open-retina/pull/46 accidentally (I think) removed the val_clip_idx parameter.
The PR additionally updates the data used for training the core_readout lightning model to the newest version.