### PR TITLE
Bugfix: pass lightning model boolean flag to model loading

### DIFF
--- a/openretina/hoefling_2024/models.py
+++ b/openretina/hoefling_2024/models.py
@@ -526,7 +526,7 @@ class SpatialXFeature3d(nn.Module):
             axes[1].bar(range(features_neuron.shape[0]), features_neuron)
             axes[1].set_ylim((features_min, features_max))
 
-            plot_path = f"{folder_path}/neuron_{neuron_id}.pdf"
+            plot_path = f"{folder_path}/neuron_{neuron_id}.jpg"
             fig_axes_tuple[0].savefig(plot_path, bbox_inches="tight", facecolor="w", dpi=300)
             fig_axes_tuple[0].clf()
             plt.close()

--- a/scripts/visualize_model_neurons.py
+++ b/scripts/visualize_model_neurons.py
@@ -193,7 +193,8 @@ def main(
     if core_readout_lightning:
         model.save_weight_visualizations(save_folder)
     else:
-        model = load_model(model_path, device=device, model_id=model_id, do_center_readout=False)
+        model = load_model(model_path, device=device, model_id=model_id, do_center_readout=False,
+                           core_readout_lightning=core_readout_lightning)
         model.to(device).eval()
         for session_key in model_readout_keys:
             folder_path = f"{save_folder}/weights_readout/{session_key}"


### PR DESCRIPTION
Changes:
- Consistently pass core_readout_lightning boolean flag to load_model function
- Consistently store all images as jpg (a single call was using pdf)