### PR TITLE
Load hoefling 2024 model from remote

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,4 @@ random.ipynb
 figures/
 /models
 reports/
+model-cache/

--- a/openretina/hoefling_2024/nnfabrik_model_loading.py
+++ b/openretina/hoefling_2024/nnfabrik_model_loading.py
@@ -8,12 +8,14 @@ from copy import deepcopy
 from functools import partial
 from importlib import import_module
 from typing import Tuple, Optional
+from pathlib import Path
 
 import torch
 import torch.nn as nn
 import yaml
 
 from openretina.utils.misc import SafeLoaderWithTuple, tuple_constructor
+from openretina.utils.file_utils import optionally_download
 
 
 def split_module_name(abs_class_name: str) -> Tuple[str, str]:
@@ -327,3 +329,23 @@ class EnsembleModel(nn.Module):
 
     def __repr__(self):
         return f"{self.__class__.__qualname__}({', '.join(m.__repr__() for m in self.members)})"
+
+
+def load_ensemble_model_from_remote(
+        remote_url: str = "https://gin.g-node.org/eulerlab/rgc-natstim/raw/master",
+        model_path: str = "models/nonlinear/9d574ab9fcb85e8251639080c8d402b7",
+        device: str = "cpu",
+        center_readout: Optional[Center] = None,
+) -> Tuple:
+    local_folders = []
+    for id_ in ["00000", "01000", "02000", "03000", "04000"]:
+        for prefix, postfix in [("config_", ".yaml"), ("data_info_", ".pkl"), ("state_dict_", ".pth.tar")]:
+            file_name = prefix + id_ + postfix
+            file_path = f"{model_path}/{file_name}"
+            local_path = optionally_download(remote_url, file_path)
+            assert local_path.endswith(file_path)
+            local_folders.append(local_path[:-len(file_name)])
+    assert len(set(local_folders)) == 1
+    local_folder = local_folders[0]
+    data_info, ensemble_model = load_ensemble_retina_model_from_directory(local_folder, device, center_readout)
+    return data_info, ensemble_model

--- a/openretina/hoefling_2024/nnfabrik_model_loading.py
+++ b/openretina/hoefling_2024/nnfabrik_model_loading.py
@@ -8,7 +8,6 @@ from copy import deepcopy
 from functools import partial
 from importlib import import_module
 from typing import Tuple, Optional
-from pathlib import Path
 
 import torch
 import torch.nn as nn

--- a/openretina/utils/file_utils.py
+++ b/openretina/utils/file_utils.py
@@ -1,0 +1,23 @@
+import os
+from pathlib import Path
+import requests
+
+
+MODEL_CACHE_DIRECTORY = "./model-cache"
+
+
+def optionally_download(
+    base_url: str,
+    path: str,
+) -> str:
+    model_cache_path = f"{MODEL_CACHE_DIRECTORY}/{path}"
+    os.makedirs(Path(model_cache_path).parent, exist_ok=True)
+    if not os.path.exists(model_cache_path):
+        full_url = f"{base_url}/{path}"
+        response = requests.get(full_url)
+        if response.status_code != 200:
+            raise FileNotFoundError(f"Received status code {response.status_code} "
+                                    f"when trying to download from {full_url=}")
+        with open(model_cache_path, "wb") as f:
+            f.write(response.content)
+    return model_cache_path

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ pytest
 types-psutil
 types-tqdm
 types-PyYAML
+types-requests


### PR DESCRIPTION
This adds a function that directly loads the model in Hoefling 2024 from https://gin.g-node.org/eulerlab/rgc-natstim.