### PR TITLE
Dev: Test ensemble model loading

### DIFF
--- a/openretina/models/core_readout.py
+++ b/openretina/models/core_readout.py
@@ -350,7 +350,7 @@ class CoreReadout(lightning.LightningModule):
             maxpool_every_n_layers=maxpool_every_n_layers,
             downsample_input_kernel_size=downsample_input_kernel_size,
         )
-        # Run one forward path to determine output shape of core
+        # Run one forward pass to determine output shape of core
         example_input = torch.zeros((1,) + tuple(in_shape))
         core_test_output = self.core.to(device).forward(example_input.to(device))
         in_shape_readout: tuple[int, int, int, int] = core_test_output.shape[1:]  # type: ignore
@@ -504,7 +504,7 @@ class GRUCoreReadout(CoreReadout):
             use_projections=core_use_projections,
             gru_kwargs=core_gru_kwargs,
         )
-        # Run one forward path to determine output shape of core
+        # Run one forward pass to determine output shape of core
         core_test_output = self.core.forward(torch.zeros((1,) + tuple(in_shape)))
         in_shape_readout: tuple[int, int, int, int] = core_test_output.shape[1:]  # type: ignore
         print(f"{in_shape_readout=}")

--- a/tests/hoefling_2024/test_nn_fabrik_model_loading.py
+++ b/tests/hoefling_2024/test_nn_fabrik_model_loading.py
@@ -1,0 +1,27 @@
+from typing import Optional
+import pytest
+import torch
+
+from openretina.hoefling_2024.nnfabrik_model_loading import load_ensemble_model_from_remote, Center
+
+
+@pytest.mark.parametrize(
+    "session_id, center_readout",
+    [
+        ("2_ventral2_20201016", None),
+        ("1_ventral1_20201021", None),
+        ("2_ventral1_20201021", Center(target_mean=(0.0, 0.0))),
+    ],
+)
+def test_loading_model_from_remote(session_id: str, center_readout: Optional[Center]) -> None:
+    data_info, ensemble_model = load_ensemble_model_from_remote(device="cpu", center_readout=center_readout)
+    assert session_id in data_info
+
+    # run a forward path with a zero tensor of batch size 1
+    input_dim = data_info[session_id]["input_dimensions"]
+    input_dim_batch_size_one = (1, ) + input_dim[1:]
+    inp_ = torch.zeros(input_dim_batch_size_one)
+    out = ensemble_model(inp_, session_id)
+
+    expected_output_dim = (1, input_dim[2] - 30, data_info[session_id]["output_dimension"])
+    assert out.shape == expected_output_dim

--- a/tests/hoefling_2024/test_nn_fabrik_model_loading.py
+++ b/tests/hoefling_2024/test_nn_fabrik_model_loading.py
@@ -1,8 +1,9 @@
 from typing import Optional
+
 import pytest
 import torch
 
-from openretina.hoefling_2024.nnfabrik_model_loading import load_ensemble_model_from_remote, Center
+from openretina.hoefling_2024.nnfabrik_model_loading import Center, load_ensemble_model_from_remote
 
 
 @pytest.mark.parametrize(

--- a/tests/hoefling_2024/test_nn_fabrik_model_loading.py
+++ b/tests/hoefling_2024/test_nn_fabrik_model_loading.py
@@ -18,7 +18,7 @@ def test_loading_model_from_remote(session_id: str, center_readout: Optional[Cen
     data_info, ensemble_model = load_ensemble_model_from_remote(device="cpu", center_readout=center_readout)
     assert session_id in data_info
 
-    # run a forward path with a zero tensor of batch size 1
+    # run a forward pass with a zero tensor of batch size 1
     input_dim = data_info[session_id]["input_dimensions"]
     input_dim_batch_size_one = (1,) + input_dim[1:]
     inp_ = torch.zeros(input_dim_batch_size_one)

--- a/tests/hoefling_2024/test_nn_fabrik_model_loading.py
+++ b/tests/hoefling_2024/test_nn_fabrik_model_loading.py
@@ -19,7 +19,7 @@ def test_loading_model_from_remote(session_id: str, center_readout: Optional[Cen
 
     # run a forward path with a zero tensor of batch size 1
     input_dim = data_info[session_id]["input_dimensions"]
-    input_dim_batch_size_one = (1, ) + input_dim[1:]
+    input_dim_batch_size_one = (1,) + input_dim[1:]
     inp_ = torch.zeros(input_dim_batch_size_one)
     out = ensemble_model(inp_, session_id)
 


### PR DESCRIPTION
This test just checks if the model can be downloaded from the GIN node and then runs a forward path using the downloaded model.

This is useful as this test will break if somebody renames the classes the model uses, e.g. renaming `EnsembleModel` to `EnsembleModels` in the following code will make the test fail:
https://github.com/open-retina/open-retina/blob/e143c8720ba261b1c9ee6e3e5fa0fa8c019aec25/openretina/hoefling_2024/nnfabrik_model_loading.py#L295