### PR TITLE
Reset adam parameters on LR reset, better logging and MovieSampler fix

### DIFF
--- a/configs/example_train_core_readout.yaml
+++ b/configs/example_train_core_readout.yaml
@@ -2,7 +2,7 @@ defaults:
   - _self_
   - quality_checks: hoefling_2024
 
-exp_name: example_core_readout_negative_optim_reset_prec16
+exp_name: example_core_readout_filtered
 data_folder: "/gpfs01/euler/data/SharedFiles/projects/TP12/"
 movies_filename: "2024-10-11_movies_dict_72x64_joint_normalised.pkl"
 responses_filename: "2024-08-14_neuron_data_responses_484c12d_djimaging.h5"

--- a/configs/example_train_core_readout.yaml
+++ b/configs/example_train_core_readout.yaml
@@ -1,4 +1,8 @@
-exp_name: example_core_readout
+defaults:
+  - _self_
+  - quality_checks: hoefling_2024
+
+exp_name: example_core_readout_negative_optim_reset_prec16
 data_folder: "/gpfs01/euler/data/SharedFiles/projects/TP12/"
 movies_filename: "2024-10-11_movies_dict_72x64_joint_normalised.pkl"
 responses_filename: "2024-08-14_neuron_data_responses_484c12d_djimaging.h5"

--- a/configs/example_train_core_readout.yaml
+++ b/configs/example_train_core_readout.yaml
@@ -8,6 +8,7 @@ movies_filename: "2024-10-11_movies_dict_72x64_joint_normalised.pkl"
 responses_filename: "2024-08-14_neuron_data_responses_484c12d_djimaging.h5"
 save_folder: exp/
 max_epochs: 100
+seed: 42
 
 core_readout:
   in_channels: 2

--- a/configs/example_train_core_readout.yaml
+++ b/configs/example_train_core_readout.yaml
@@ -47,3 +47,8 @@ training_callbacks:
     patience: 15
     verbose: True
     mode: "max"
+  lr_monitor:
+    _target_: lightning.pytorch.callbacks.LearningRateMonitor
+    logging_interval: "epoch"
+    log_momentum: true
+    log_weight_decay: true

--- a/configs/example_train_core_readout_low_res.yaml
+++ b/configs/example_train_core_readout_low_res.yaml
@@ -20,7 +20,7 @@ core_readout:
   gaussian_masks: True
   gaussian_mean_scale: 6.0
   gaussian_var_scale: 4.0
-  positive: False
+  positive: True
   gamma_readout: 0.4
   learning_rate: 0.01
   cut_first_n_frames_in_core: 30

--- a/configs/example_train_core_readout_low_res.yaml
+++ b/configs/example_train_core_readout_low_res.yaml
@@ -8,6 +8,7 @@ movies_filename: "2024-01-11_movies_dict_8c18928.pkl"
 responses_filename: "2024-08-14_neuron_data_responses_484c12d_djimaging.h5"
 save_folder: exp/
 max_epochs: 100
+seed: 42
 
 core_readout:
   in_channels: 2

--- a/configs/example_train_core_readout_low_res.yaml
+++ b/configs/example_train_core_readout_low_res.yaml
@@ -1,4 +1,8 @@
-exp_name: example_core_readout_low_res
+defaults:
+  - _self_
+  - quality_checks: hoefling_2024
+
+exp_name: example_core_readout_low_res_filtered
 data_folder: "/gpfs01/euler/data/SharedFiles/projects/TP12/"
 movies_filename: "2024-01-11_movies_dict_8c18928.pkl"
 responses_filename: "2024-08-14_neuron_data_responses_484c12d_djimaging.h5"
@@ -16,7 +20,7 @@ core_readout:
   gaussian_masks: True
   gaussian_mean_scale: 6.0
   gaussian_var_scale: 4.0
-  positive: True
+  positive: False
   gamma_readout: 0.4
   learning_rate: 0.01
   cut_first_n_frames_in_core: 30

--- a/configs/example_train_core_readout_low_res.yaml
+++ b/configs/example_train_core_readout_low_res.yaml
@@ -45,3 +45,9 @@ training_callbacks:
     patience: 15
     verbose: True
     mode: "max"
+  lr_monitor:
+    _target_: lightning.pytorch.callbacks.LearningRateMonitor
+    logging_interval: "epoch"
+    log_momentum: true
+    log_weight_decay: true
+

--- a/openretina/dataloaders.py
+++ b/openretina/dataloaders.py
@@ -82,9 +82,7 @@ class MovieSampler(Sampler):
                     np.arange(0, self.movie_length + 1, self.scene_length),
                     self.indices,
                     self.chunk_size,
-                    self.allow_over_boundaries,
                 )
-
             # Shuffle the indices
             indices_shuffling = np.random.permutation(len(self.indices))
         else:
@@ -97,7 +95,7 @@ class MovieSampler(Sampler):
         return len(self.indices)
 
 
-def gen_shifts(clip_bounds, start_indices, clip_chunk_size=50, allow_over_boundaries=False):
+def gen_shifts(clip_bounds, start_indices, clip_chunk_size=50):
     """
     Generate shifted indices based on clip bounds and start indices.
     Assumes that the original start indices are already within the clip bounds.
@@ -124,18 +122,15 @@ def gen_shifts(clip_bounds, start_indices, clip_chunk_size=50, allow_over_bounda
 
     for i, start_idx in enumerate(start_indices):
         next_bound = get_next_bound(start_idx, clip_bounds)
-        if allow_over_boundaries:
+        if start_idx + shifts[i] + clip_chunk_size < next_bound:
             shifted_indices.append(start_idx + shifts[i])
+        elif start_idx + clip_chunk_size > next_bound:
+            shifted_indices.append(next_bound - clip_chunk_size)
         else:
-            if start_idx + shifts[i] + clip_chunk_size < next_bound:
-                shifted_indices.append(start_idx + shifts[i])
-            elif start_idx + clip_chunk_size > next_bound:
-                shifted_indices.append(next_bound - clip_chunk_size)
-            else:
-                shifted_indices.append(start_idx)
+            shifted_indices.append(start_idx)
 
     # Ensure we do not exceed the movie length when allowing over boundaries
-    if allow_over_boundaries and shifted_indices[-1] + clip_chunk_size > clip_bounds[-1]:
+    if shifted_indices[-1] + clip_chunk_size > clip_bounds[-1]:
         shifted_indices[-1] = clip_bounds[-1] - clip_chunk_size
     return shifted_indices
 

--- a/openretina/dataloaders.py
+++ b/openretina/dataloaders.py
@@ -117,7 +117,7 @@ def gen_shifts_with_boundaries(
         return bounds[min(insertion_index, len(bounds) - 1)]
 
     shifted_indices = []
-    shifts = np.random.randint(1, clip_chunk_size // 2, len(start_indices))
+    shifts = np.random.randint(0, clip_chunk_size // 2, len(start_indices))
 
     for i, start_idx in enumerate(start_indices):
         next_bound = get_next_bound(start_idx, clip_bounds)

--- a/openretina/dataloaders.py
+++ b/openretina/dataloaders.py
@@ -74,12 +74,16 @@ class MovieSampler(Sampler):
         if self.split == "train" and (self.scene_length != self.chunk_size):
             # Always start the clip from a random point in the scene, within the chosen chunk size
             # All while making sure it does not go over the scene length bound.
-            shifted_indices = gen_shifts(
-                np.arange(0, self.movie_length + 1, self.scene_length),
-                self.indices,
-                self.chunk_size,
-                self.allow_over_boundaries,
-            )
+            if self.allow_over_boundaries:
+                shifts = np.random.randint(0, self.scene_length, len(self.indices))
+                shifted_indices = np.minimum(self.indices + shifts, self.movie_length - self.chunk_size)
+            else:
+                shifted_indices = gen_shifts(
+                    np.arange(0, self.movie_length + 1, self.scene_length),
+                    self.indices,
+                    self.chunk_size,
+                    self.allow_over_boundaries,
+                )
 
             # Shuffle the indices
             indices_shuffling = np.random.permutation(len(self.indices))

--- a/openretina/models/core_readout.py
+++ b/openretina/models/core_readout.py
@@ -384,7 +384,7 @@ class CoreReadout(lightning.LightningModule):
 
     def get_last_lr(self) -> float:
         try:
-            return self.lr_schedulers().get_last_lr()[0]
+            return self.lr_schedulers().get_last_lr()[0]  # type: ignore
         except:  # noqa
             return -1.0
 

--- a/openretina/models/core_readout.py
+++ b/openretina/models/core_readout.py
@@ -382,12 +382,6 @@ class CoreReadout(lightning.LightningModule):
         readout_norms = grad_norm(self.readout, norm_type=2)
         self.log_dict(readout_norms, on_step=False, on_epoch=True)
 
-    def get_last_lr(self) -> float:
-        try:
-            return self.lr_schedulers().get_last_lr()[0]  # type: ignore
-        except:  # noqa
-            return -1.0
-
     def forward(self, x: torch.Tensor, data_key: str) -> torch.Tensor:
         output_core = self.core(x)
         output_readout = self.readout(output_core, data_key=data_key)
@@ -419,7 +413,6 @@ class CoreReadout(lightning.LightningModule):
         total_loss = loss + regularization_loss_core + regularization_loss_readout
         correlation = -self.correlation_loss.forward(model_output, data_point.targets)
 
-        self.log("learning_rate", self.get_last_lr(), logger=True)
         self.log("val_loss", loss, logger=True, prog_bar=True)
         self.log("val_regularization_loss_core", regularization_loss_core, logger=True)
         self.log("val_regularization_loss_readout", regularization_loss_readout, logger=True)

--- a/openretina/models/core_readout.py
+++ b/openretina/models/core_readout.py
@@ -378,9 +378,9 @@ class CoreReadout(lightning.LightningModule):
         # Compute the 2-norm for each layer
         # If using mixed precision, the gradients are already unscaled here
         core_norms = grad_norm(self.core, norm_type=2)
-        self.log_dict(core_norms)
+        self.log_dict(core_norms, on_step=False, on_epoch=True)
         readout_norms = grad_norm(self.readout, norm_type=2)
-        self.log_dict(readout_norms)
+        self.log_dict(readout_norms, on_step=False, on_epoch=True)
 
     def get_last_lr(self) -> float:
         try:

--- a/openretina/models/core_readout.py
+++ b/openretina/models/core_readout.py
@@ -3,10 +3,10 @@ from collections import OrderedDict
 from typing import Iterable, Optional
 
 import lightning
-from lightning.pytorch.utilities import grad_norm
 import matplotlib.pyplot as plt
 import numpy as np
 import torch
+from lightning.pytorch.utilities import grad_norm
 from matplotlib.colors import Normalize
 from torch import nn
 
@@ -385,7 +385,7 @@ class CoreReadout(lightning.LightningModule):
     def get_last_lr(self) -> float:
         try:
             return self.lr_schedulers().get_last_lr()[0]
-        except:
+        except:  # noqa
             return -1.0
 
     def forward(self, x: torch.Tensor, data_key: str) -> torch.Tensor:

--- a/openretina/models/model_utils.py
+++ b/openretina/models/model_utils.py
@@ -1,6 +1,7 @@
 from contextlib import contextmanager
 
 import torch
+from lightning.pytorch.callbacks import Callback
 
 
 def get_module_output_shape(
@@ -41,3 +42,41 @@ def eval_state(model: torch.nn.Module):
         yield model
     finally:
         model.train(training_status)
+
+
+class OptimizerResetCallback(Callback):
+    def __init__(self):
+        super().__init__()
+        self.prev_lr = None  # This will store the previous learning rate
+
+    def on_validation_end(self, trainer, pl_module):
+        # Get the current learning rate from the optimizer
+        optims = pl_module.optimizers()
+        try:
+            optim = optims[0]
+        except:  # noqa
+            optim = optims
+        current_lr = optim.param_groups[0]["lr"]
+
+        # Compare with the previous learning rate
+        if self.prev_lr is not None and current_lr < self.prev_lr:
+            print(f"Learning rate decreased from {self.prev_lr} to {current_lr}. Resetting optimizer.")
+            # Reset the optimizer if the learning rate has decreased
+            params_dict = optim.param_groups[0]
+            # below could be written shorter
+            new_optimizer = torch.optim.AdamW(
+                pl_module.parameters(),
+                lr=current_lr,
+                betas=params_dict["betas"],
+                eps=params_dict["eps"],
+                weight_decay=params_dict["weight_decay"],
+                amsgrad=params_dict["amsgrad"],
+                maximize=params_dict["maximize"],
+                foreach=params_dict["foreach"],
+                capturable=params_dict["capturable"],
+                differentiable=params_dict["differentiable"],
+                fused=params_dict["fused"],
+            )
+            trainer.optimizers = [new_optimizer]  # Replace the optimizer in the trainer
+
+        self.prev_lr = current_lr

--- a/scripts/train_core_readout.py
+++ b/scripts/train_core_readout.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+from typing import Literal
 import os
 import pickle
 
@@ -39,7 +40,7 @@ def main(conf: DictConfig) -> None:
     valid_loader = torch.utils.data.DataLoader(LongCycler(dataloaders["validation"], shuffle=False), **conf.dataloader)
 
     # max_pool3d_with_indices does not have a deterministic implementation in pytorch yet
-    deterministic = "warn" if conf.seed is not None else False
+    deterministic: bool | Literal["warn"]  = "warn" if conf.seed is not None else False
     if conf.seed is not None:
         lightning.pytorch.seed_everything(conf.seed)
 

--- a/scripts/train_core_readout.py
+++ b/scripts/train_core_readout.py
@@ -38,6 +38,10 @@ def main(conf: DictConfig) -> None:
     train_loader = torch.utils.data.DataLoader(LongCycler(dataloaders["train"], shuffle=True), **conf.dataloader)
     valid_loader = torch.utils.data.DataLoader(LongCycler(dataloaders["validation"], shuffle=False), **conf.dataloader)
 
+    deterministic = conf.seed is not None
+    if deterministic:
+        print(f"Using deterministic mode with {conf.seed=}")
+        lightning.pytorch.seed_everything(conf.seed)
     n_neurons_dict = {name: data_point.targets.shape[-1] for name, data_point in iter(train_loader)}
     model = CoreReadout(
         n_neurons_dict=n_neurons_dict,
@@ -62,6 +66,7 @@ def main(conf: DictConfig) -> None:
         logger=logger_array,
         callbacks=callbacks,
         accumulate_grad_batches=1,
+        deterministic=deterministic,
     )
     trainer.fit(model=model, train_dataloaders=train_loader, val_dataloaders=valid_loader)
     # test

--- a/scripts/train_core_readout.py
+++ b/scripts/train_core_readout.py
@@ -40,8 +40,9 @@ def main(conf: DictConfig) -> None:
 
     deterministic = conf.seed is not None
     if deterministic:
-        print(f"Using deterministic mode with {conf.seed=}")
         lightning.pytorch.seed_everything(conf.seed)
+        # max_pool3d_with_indices does not have a deterministic implementation in pytorch yet
+        torch.use_deterministic_algorithms(True, warn_only=False)
     n_neurons_dict = {name: data_point.targets.shape[-1] for name, data_point in iter(train_loader)}
     model = CoreReadout(
         n_neurons_dict=n_neurons_dict,

--- a/scripts/train_core_readout.py
+++ b/scripts/train_core_readout.py
@@ -38,11 +38,11 @@ def main(conf: DictConfig) -> None:
     train_loader = torch.utils.data.DataLoader(LongCycler(dataloaders["train"], shuffle=True), **conf.dataloader)
     valid_loader = torch.utils.data.DataLoader(LongCycler(dataloaders["validation"], shuffle=False), **conf.dataloader)
 
-    deterministic = conf.seed is not None
-    if deterministic:
+    # max_pool3d_with_indices does not have a deterministic implementation in pytorch yet
+    deterministic = "warn" if conf.seed is not None else False
+    if conf.seed is not None:
         lightning.pytorch.seed_everything(conf.seed)
-        # max_pool3d_with_indices does not have a deterministic implementation in pytorch yet
-        torch.use_deterministic_algorithms(True, warn_only=False)
+
     n_neurons_dict = {name: data_point.targets.shape[-1] for name, data_point in iter(train_loader)}
     model = CoreReadout(
         n_neurons_dict=n_neurons_dict,

--- a/scripts/train_core_readout.py
+++ b/scripts/train_core_readout.py
@@ -6,7 +6,7 @@ import pickle
 import hydra
 import lightning
 import torch
-from lightning.pytorch.callbacks import Callback, ModelCheckpoint
+from lightning.pytorch.callbacks import ModelCheckpoint
 from omegaconf import DictConfig, OmegaConf
 
 from openretina.cyclers import LongCycler
@@ -14,46 +14,9 @@ from openretina.hoefling_2024.data_io import (
     natmov_dataloaders_v2,
 )
 from openretina.models.core_readout import CoreReadout
+from openretina.models.model_utils import OptimizerResetCallback
 from openretina.neuron_data_io import filter_responses, make_final_responses
 from openretina.utils.h5_handling import load_h5_into_dict
-
-
-class OptimizerResetCallback(Callback):
-    def __init__(self):
-        super().__init__()
-        self.prev_lr = None  # This will store the previous learning rate
-
-    def on_validation_end(self, trainer, pl_module):
-        # Get the current learning rate from the optimizer
-        optims = pl_module.optimizers()
-        try:
-            optim = optims[0]
-        except:  # noqa
-            optim = optims
-        current_lr = optim.param_groups[0]["lr"]
-
-        # Compare with the previous learning rate
-        if self.prev_lr is not None and current_lr < self.prev_lr:
-            print(f"Learning rate decreased from {self.prev_lr} to {current_lr}. Resetting optimizer.")
-            # Reset the optimizer if the learning rate has decreased
-            params_dict = optim.param_groups[0]
-            # below could be written shorter
-            new_optimizer = torch.optim.AdamW(
-                pl_module.parameters(),
-                lr=current_lr,
-                betas=params_dict["betas"],
-                eps=params_dict["eps"],
-                weight_decay=params_dict["weight_decay"],
-                amsgrad=params_dict["amsgrad"],
-                maximize=params_dict["maximize"],
-                foreach=params_dict["foreach"],
-                capturable=params_dict["capturable"],
-                differentiable=params_dict["differentiable"],
-                fused=params_dict["fused"],
-            )
-            trainer.optimizers = [new_optimizer]  # Replace the optimizer in the trainer
-
-        self.prev_lr = current_lr
 
 
 @hydra.main(version_base=None, config_path="../example_configs", config_name="train_core_readout")

--- a/scripts/train_core_readout.py
+++ b/scripts/train_core_readout.py
@@ -35,7 +35,6 @@ class OptimizerResetCallback(Callback):
         # Compare with the previous learning rate
         if self.prev_lr is not None and current_lr < self.prev_lr:
             print(f"Learning rate decreased from {self.prev_lr} to {current_lr}. Resetting optimizer.")
- 
             # Reset the optimizer if the learning rate has decreased
             params_dict = optim.param_groups[0]
             # below could be written shorter
@@ -48,10 +47,8 @@ class OptimizerResetCallback(Callback):
                 fused=params_dict["fused"],
             )
             trainer.optimizers = [new_optimizer]  # Replace the optimizer in the trainer
-            self.prev_lr = current_lr  # Update the previous learning rate
 
-        else:
-            self.prev_lr = current_lr  # Update the previous learning rate for future comparisons
+        self.prev_lr = current_lr
 
 
 @hydra.main(version_base=None, config_path="../example_configs", config_name="train_core_readout")

--- a/scripts/train_core_readout.py
+++ b/scripts/train_core_readout.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 
-from typing import Literal
 import os
 import pickle
+from typing import Literal
 
 import hydra
 import lightning
@@ -40,7 +40,7 @@ def main(conf: DictConfig) -> None:
     valid_loader = torch.utils.data.DataLoader(LongCycler(dataloaders["validation"], shuffle=False), **conf.dataloader)
 
     # max_pool3d_with_indices does not have a deterministic implementation in pytorch yet
-    deterministic: bool | Literal["warn"]  = "warn" if conf.seed is not None else False
+    deterministic: bool | Literal["warn"] = "warn" if conf.seed is not None else False
     if conf.seed is not None:
         lightning.pytorch.seed_everything(conf.seed)
 


### PR DESCRIPTION
- Re-initialize the Adam if the learning rate was changed by using a new class called OptimizerResetCallback
- Refactor MovieSampler and generate shifts from 0 to clip_chunk_size when not enforcing scene boundaries
- Better logging:
   - Log learning rate
   - Log training stats per epoch leading to smoother and easier comparable graphs
   - Log gradient magnitudes
- Change precision=16 to precision="16-mixed" as this is recommended by pytorch lightning
- Filter data by default based by removing low quality cells

# Results

## Low res
```
───────────────────────────────────────────────────────────────────────────────────────────────────────────────
       Test metric             DataLoader 0             DataLoader 1             DataLoader 2                                                                                                               
───────────────────────────────────────────────────────────────────────────────────────────────────────────────
    test_correlation        0.22427836060523987      0.2659996449947357       0.4651343822479248                                                                                                            
        test_loss            534.9968872070312        375.6442565917969        38.34758377075195                                                                                                            
───────────────────────────────────────────────────────────────────────────────────────────────────────────────
```
With seed 42:
```
    test_correlation        0.20960338413715363      0.24668897688388824      0.4416184425354004                                                                               
        test_loss            535.2044067382812        377.0640869140625        37.99009704589844 
```

## High Res
With seed 42 (but one layer does not support deterministic mode):
```
────────────────────────────
       Test metric             DataLoader 0             DataLoader 1             DataLoader 2
───────────────────────────────────────────────────
    test_correlation        0.28346744179725647      0.33637067675590515       0.524970531463623
        test_loss            520.753662109375         364.3420715332031        38.09238052368164
────────────────────────────────────────────────────────────
```