### PR TITLE
Support downloading files directly from gin server

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   unit-tests:
-    runs-on: [ubuntu-latest, windows-latest]
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   unit-tests:
-    runs-on: ubuntu-latest
+    runs-on: [ubuntu-latest, windows-latest]
 
     steps:
       - name: Checkout repository

--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,4 @@ figures/
 reports/
 model-cache/
 /exp
+/cache_folder

--- a/.gitignore
+++ b/.gitignore
@@ -175,4 +175,4 @@ figures/
 reports/
 model-cache/
 /exp
-/cache_folder
+openretina_cache_folder/

--- a/configs/example_train_core_readout.yaml
+++ b/configs/example_train_core_readout.yaml
@@ -4,9 +4,9 @@ defaults:
   - dataloader@natmov_dataloader: hoefling_2024 # looks for default under "dataloader" and names it "natmov_dataloader"
 
 exp_name: example_core_readout_filtered
-data_folder: "/gpfs01/euler/data/SharedFiles/projects/TP12/"
-movies_filename: "2024-10-11_movies_dict_72x64_joint_normalised.pkl"
-responses_filename: "2024-08-14_neuron_data_responses_484c12d_djimaging.h5"
+cache_folder: "./cache_folder/"
+movies_path: "https://gin.g-node.org/teulerlab/open-retina/raw/master/stimuli/eulerlab/rgc_natstim_72x64_joint_normalized_2024-10-11.pkl"
+responses_path: "https://gin.g-node.org/teulerlab/open-retina/raw/master/responses/eulerlab/rgc_natstim_2024-08-14.h5"
 save_folder: exp/
 max_epochs: 100
 seed: 42

--- a/configs/example_train_core_readout.yaml
+++ b/configs/example_train_core_readout.yaml
@@ -4,7 +4,7 @@ defaults:
   - dataloader@natmov_dataloader: hoefling_2024 # looks for default under "dataloader" and names it "natmov_dataloader"
 
 exp_name: example_core_readout_filtered
-cache_folder: "./cache_folder/"
+cache_folder: "./openretina_cache_folder/"
 movies_path: "https://gin.g-node.org/teulerlab/open-retina/raw/master/stimuli/eulerlab/rgc_natstim_72x64_joint_normalized_2024-10-11.pkl"
 responses_path: "https://gin.g-node.org/teulerlab/open-retina/raw/master/responses/eulerlab/rgc_natstim_2024-08-14.h5"
 save_folder: exp/

--- a/configs/example_train_core_readout_low_res.yaml
+++ b/configs/example_train_core_readout_low_res.yaml
@@ -4,7 +4,7 @@ defaults:
   - dataloader@natmov_dataloader: hoefling_2024 # looks for default under "dataloader" and names it "natmov_dataloader"
 
 exp_name: example_core_readout_low_res_filtered
-cache_folder: "./cache_folder/"
+cache_folder: "./openretina_cache_folder/"
 movies_path: "https://gin.g-node.org/teulerlab/open-retina/raw/master/stimuli/eulerlab/rgc_natstim_18x16_joint_normalized_2024-01-11.pkl"
 responses_path: "https://gin.g-node.org/teulerlab/open-retina/raw/master/responses/eulerlab/rgc_natstim_2024-08-14.h5"
 save_folder: exp/

--- a/configs/example_train_core_readout_low_res.yaml
+++ b/configs/example_train_core_readout_low_res.yaml
@@ -4,9 +4,9 @@ defaults:
   - dataloader@natmov_dataloader: hoefling_2024 # looks for default under "dataloader" and names it "natmov_dataloader"
 
 exp_name: example_core_readout_low_res_filtered
-data_folder: "/gpfs01/euler/data/SharedFiles/projects/TP12/"
-movies_filename: "2024-01-11_movies_dict_8c18928.pkl"
-responses_filename: "2024-08-14_neuron_data_responses_484c12d_djimaging.h5"
+cache_folder: "./cache_folder/"
+movies_path: "https://gin.g-node.org/teulerlab/open-retina/raw/master/stimuli/eulerlab/rgc_natstim_18x16_joint_normalized_2024-01-11.pkl"
+responses_path: "https://gin.g-node.org/teulerlab/open-retina/raw/master/responses/eulerlab/rgc_natstim_2024-08-14.h5"
 save_folder: exp/
 max_epochs: 100
 seed: 42

--- a/openretina/data_io/base.py
+++ b/openretina/data_io/base.py
@@ -1,5 +1,6 @@
 import pickle
 import warnings
+from pathlib import Path
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
@@ -28,7 +29,7 @@ class MoviesTrainTestSplit:
             )
 
     @classmethod
-    def from_pickle(cls, file_path: str):
+    def from_pickle(cls, file_path: str | Path):
         with open(file_path, "rb") as f:
             movies_dict = pickle.load(f)
         return cls(

--- a/openretina/data_io/base.py
+++ b/openretina/data_io/base.py
@@ -1,7 +1,7 @@
 import pickle
 import warnings
-from pathlib import Path
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Optional
 
 import numpy as np

--- a/openretina/utils/file_utils.py
+++ b/openretina/utils/file_utils.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import requests
 
-
 LOGGER = logging.getLogger(__name__)
 _DEFAULT_CACHE_DIRECTORY = "./cache_folder"
 GIN_BASE_URL = "https://gin.g-node.org/"
@@ -36,7 +35,7 @@ def get_local_file_path(file_path: str, cache_folder: str) -> Path:
         # gin node
         return optionally_download_from_url(
             GIN_BASE_URL,
-            file_path[len(GIN_BASE_URL):],
+            file_path[len(GIN_BASE_URL) :],
             os.path.expanduser(cache_folder),
         )
     elif file_path.startswith("http"):

--- a/openretina/utils/file_utils.py
+++ b/openretina/utils/file_utils.py
@@ -6,7 +6,7 @@ import requests
 import tenacity
 
 LOGGER = logging.getLogger(__name__)
-_DEFAULT_CACHE_DIRECTORY = "cache_folder"
+_DEFAULT_CACHE_DIRECTORY = "openretina_cache_folder"
 GIN_BASE_URL = "https://gin.g-node.org/"
 
 

--- a/openretina/utils/file_utils.py
+++ b/openretina/utils/file_utils.py
@@ -1,24 +1,46 @@
+import logging
 import os
 from pathlib import Path
 
 import requests
 
-MODEL_CACHE_DIRECTORY = "./model-cache"
+
+LOGGER = logging.getLogger(__name__)
+_DEFAULT_CACHE_DIRECTORY = "./cache_folder"
+GIN_BASE_URL = "https://gin.g-node.org/"
 
 
-def optionally_download(
+def optionally_download_from_url(
     base_url: str,
     path: str,
-) -> str:
-    model_cache_path = f"{MODEL_CACHE_DIRECTORY}/{path}"
-    os.makedirs(Path(model_cache_path).parent, exist_ok=True)
-    if not os.path.exists(model_cache_path):
+    cache_folder: str,
+) -> Path:
+    cache_path = Path(cache_folder) / Path(path)
+    os.makedirs(Path(cache_path).parent, exist_ok=True)
+    if not os.path.exists(cache_path):
         full_url = f"{base_url}/{path}"
+        LOGGER.info(f"Downloading {full_url} ...")
         response = requests.get(full_url)
         if response.status_code != 200:
             raise FileNotFoundError(
                 f"Received status code {response.status_code} " f"when trying to download from {full_url=}"
             )
-        with open(model_cache_path, "wb") as f:
+        with open(cache_path, "wb") as f:
             f.write(response.content)
-    return model_cache_path
+        LOGGER.info(f"Stored contents of {full_url} in {cache_path}")
+    return cache_path
+
+
+def get_local_file_path(file_path: str, cache_folder: str) -> Path:
+    if file_path.startswith(GIN_BASE_URL):
+        # gin node
+        return optionally_download_from_url(
+            GIN_BASE_URL,
+            file_path[len(GIN_BASE_URL):],
+            os.path.expanduser(cache_folder),
+        )
+    elif file_path.startswith("http"):
+        raise ValueError(f"Downloading from http {file_path=} is not supported yet.")
+    else:
+        # assuming this is a local file
+        return Path(os.path.expanduser(file_path))

--- a/openretina/utils/h5_handling.py
+++ b/openretina/utils/h5_handling.py
@@ -1,5 +1,6 @@
 import json
 import os
+from pathlib import Path
 
 import h5py as h5
 import numpy as np
@@ -19,7 +20,7 @@ def count_items(group: h5.Group) -> int:
     return count
 
 
-def load_h5_into_dict(file_path) -> dict:
+def load_h5_into_dict(file_path: str | Path) -> dict:
     """
     Recursively loads the structure and data of the HDF5 file into a dictionary.
     """

--- a/openretina/utils/nnfabrik_model_loading.py
+++ b/openretina/utils/nnfabrik_model_loading.py
@@ -257,7 +257,7 @@ def load_ensemble_retina_model_from_directory(
         model_config_path = f"{directory_path}/config_{seed:05d}.yaml"
         data_info_path = f"{directory_path}/data_info_{seed:05d}.pkl"
 
-        state_dict = torch.load(state_dir_path)
+        state_dict = torch.load(state_dir_path, weights_only=True)
         with open(model_config_path, "r") as f:
             config = yaml.load(f, SafeLoaderWithTuple)
         with open(data_info_path, "rb") as fb:

--- a/openretina/utils/nnfabrik_model_loading.py
+++ b/openretina/utils/nnfabrik_model_loading.py
@@ -302,10 +302,9 @@ def load_ensemble_model_from_remote(
     for id_ in ["00000", "01000", "02000", "03000", "04000"]:
         for prefix, postfix in [("config_", ".yaml"), ("data_info_", ".pkl"), ("state_dict_", ".pth.tar")]:
             file_name = prefix + id_ + postfix
-            file_path = f"{model_path}/{file_name}"
-            local_path = optionally_download_from_url(remote_url, file_path)
-            assert local_path.endswith(file_path)
-            local_folders.append(local_path[: -len(file_name)])
+            server_path = f"{model_path}/{file_name}"
+            local_path = optionally_download_from_url(remote_url, server_path)
+            local_folders.append(str(local_path)[: -len(file_name)])
     assert len(set(local_folders)) == 1
     local_folder = local_folders[0]
     data_info, ensemble_model = load_ensemble_retina_model_from_directory(local_folder, device, center_readout)

--- a/openretina/utils/nnfabrik_model_loading.py
+++ b/openretina/utils/nnfabrik_model_loading.py
@@ -12,7 +12,7 @@ import torch
 import yaml
 
 from openretina.modules.layers.ensemble import EnsembleModel
-from openretina.utils.file_utils import optionally_download
+from openretina.utils.file_utils import optionally_download_from_url
 from openretina.utils.misc import SafeLoaderWithTuple, tuple_constructor
 
 
@@ -293,8 +293,8 @@ def load_ensemble_retina_model_from_directory(
 
 
 def load_ensemble_model_from_remote(
-    remote_url: str = "https://gin.g-node.org/eulerlab/rgc-natstim/raw/master",
-    model_path: str = "models/nonlinear/9d574ab9fcb85e8251639080c8d402b7",
+    remote_url: str = "https://gin.g-node.org/",
+    model_path: str = "eulerlab/rgc-natstim/raw/master/models/nonlinear/9d574ab9fcb85e8251639080c8d402b7",
     device: str = "cpu",
     center_readout: Center | None = None,
 ) -> tuple:
@@ -303,7 +303,7 @@ def load_ensemble_model_from_remote(
         for prefix, postfix in [("config_", ".yaml"), ("data_info_", ".pkl"), ("state_dict_", ".pth.tar")]:
             file_name = prefix + id_ + postfix
             file_path = f"{model_path}/{file_name}"
-            local_path = optionally_download(remote_url, file_path)
+            local_path = optionally_download_from_url(remote_url, file_path)
             assert local_path.endswith(file_path)
             local_folders.append(local_path[: -len(file_name)])
     assert len(set(local_folders)) == 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ numpy<2.0  # h5py loading does not work with 2.0
 pandas
 seaborn
 scipy
+tenacity
 tensorboard
 torch
 torchaudio

--- a/scripts/train_core_readout.py
+++ b/scripts/train_core_readout.py
@@ -16,17 +16,17 @@ from openretina.data_io.hoefling_2024.responses import filter_responses, make_fi
 from openretina.models.core_readout import CoreReadout
 from openretina.utils.h5_handling import load_h5_into_dict
 from openretina.utils.model_utils import OptimizerResetCallback
+from openretina.utils.file_utils import get_local_file_path
 
 
 @hydra.main(version_base=None, config_path="../configs", config_name="example_train_core_readout")
 def main(conf: DictConfig) -> None:
     hydra.utils.call(conf.matmul_precision)
 
-    data_folder = os.path.expanduser(conf.data_folder)
-    movies_path = os.path.join(data_folder, conf.movies_filename)
+    movies_path = get_local_file_path(conf.movies_path, conf.cache_folder)
     movies_dict = MoviesTrainTestSplit.from_pickle(movies_path)
 
-    data_path_responses = os.path.join(data_folder, conf.responses_filename)
+    data_path_responses = get_local_file_path(conf.responses_path, conf.cache_folder)
     responses = load_h5_into_dict(data_path_responses)
     filtered_responses = filter_responses(responses, **OmegaConf.to_object(conf.quality_checks))  # type: ignore
 

--- a/scripts/train_core_readout.py
+++ b/scripts/train_core_readout.py
@@ -14,9 +14,9 @@ from openretina.data_io.base import MoviesTrainTestSplit
 from openretina.data_io.cyclers import LongCycler, ShortCycler
 from openretina.data_io.hoefling_2024.responses import filter_responses, make_final_responses
 from openretina.models.core_readout import CoreReadout
+from openretina.utils.file_utils import get_local_file_path
 from openretina.utils.h5_handling import load_h5_into_dict
 from openretina.utils.model_utils import OptimizerResetCallback
-from openretina.utils.file_utils import get_local_file_path
 
 
 @hydra.main(version_base=None, config_path="../configs", config_name="example_train_core_readout")


### PR DESCRIPTION
The default config for training the core-readout models contains now urls to data on [GIN](https://gin.g-node.org/teulerlab/open-retina) (you can still define regular paths, though).
These urls are used to download the data, which gets stored in a cache directory defined in the config. The first time you run this, you'll have to wait a bit until the download finishs (you'll see a log message about this). Afterwards, the data from the cache directory is used.

To test this, run the following command to train the low res model on a small subset of the data:
```
./scripts/train_core_readout.py --config-path ~/GitRepos/open-retina/configs --config-name example_train_core_readout_low_res responses_path=https://gin.g-node.org/teulerlab/open-retina/raw/master/responses/eulerlab/rgc_natsim_subset_only_naturalspikes_2024-08-14.h5
```