### PR TITLE
Re-add readout initialisation

### DIFF
--- a/openretina/modules/readout/factorised_gaussian.py
+++ b/openretina/modules/readout/factorised_gaussian.py
@@ -45,6 +45,7 @@ class SimpleSpatialXFeature3d(torch.nn.Module):
         self.register_buffer("grid", self.make_mask_grid(outdims, w, h))
 
         self.features = nn.Parameter(torch.Tensor(1, c, 1, outdims))
+        self.features.data.normal_(1.0 / c, 0.01)
 
         if scale:
             self.scale_param = nn.Parameter(torch.ones(outdims))


### PR DESCRIPTION
With the last PR, I removed (by mistake) the readout feature weights initialisation, which was setting the weights to a random normal with mean centered around 1/n_channels.

While I did this by mistake, I was surprised to see that this was enough to make training consistently diverge within the first few gradient descent steps with both the GRU and classic core architecture (and this is how I actually found out I deleted this by mistake).