### PR TITLE
Update codestyle according to ruff-0.9

### DIFF
--- a/openretina/data_io/artificial_stimuli.py
+++ b/openretina/data_io/artificial_stimuli.py
@@ -158,9 +158,9 @@ def load_moving_bar_30hz_72_64px(
 def load_moving_bar_stack(normalize: bool = True, number_of_moving_bars: int = 8) -> np.ndarray:
     moving_bar = load_moving_bar(normalize)
 
-    assert (
-        moving_bar.shape[0] % number_of_moving_bars == 0
-    ), "Moving bar timesteps are not divisible by number_of_moving_bars, something went wrong"
+    assert moving_bar.shape[0] % number_of_moving_bars == 0, (
+        "Moving bar timesteps are not divisible by number_of_moving_bars, something went wrong"
+    )
     return np.stack(np.split(moving_bar, number_of_moving_bars, axis=0), axis=0)
 
 

--- a/openretina/data_io/base.py
+++ b/openretina/data_io/base.py
@@ -48,9 +48,9 @@ class ResponsesTrainTestSplit:
     session_kwargs: dict[str, Any] = field(default_factory=lambda: {})
 
     def __post_init__(self):
-        assert (
-            self.train.shape[0] == self.test.shape[0]
-        ), "Train and test responses should have the same number of neurons."
+        assert self.train.shape[0] == self.test.shape[0], (
+            "Train and test responses should have the same number of neurons."
+        )
         if self.train.shape[0] > self.train.shape[1]:
             warnings.warn(
                 "The number of neurons is greater than the number of timebins in the train responses. "

--- a/openretina/data_io/base_dataloader.py
+++ b/openretina/data_io/base_dataloader.py
@@ -511,9 +511,9 @@ def multiple_movies_dataloaders(
         AssertionError:
             If the keys of neuron_data_dictionary and movies_dictionary do not match exactly.
     """
-    assert set(neuron_data_dictionary.keys()) == set(
-        movies_dictionary.keys()
-    ), "The keys of neuron_data_dictionary and movies_dictionary should match exactly."
+    assert set(neuron_data_dictionary.keys()) == set(movies_dictionary.keys()), (
+        "The keys of neuron_data_dictionary and movies_dictionary should match exactly."
+    )
 
     # Initialise dataloaders
     dataloaders: dict[str, Any] = {"train": {}, "validation": {}, "test": {}}

--- a/openretina/data_io/hoefling_2024/dataloaders.py
+++ b/openretina/data_io/hoefling_2024/dataloaders.py
@@ -214,9 +214,9 @@ def get_chirp_dataloaders(
     train_chunk_size: Optional[int] = None,
     batch_size: int = 32,
 ):
-    assert isinstance(
-        neuron_data_dictionary, dict
-    ), "neuron_data_dictionary should be a dictionary of sessions and their corresponding neuron data."
+    assert isinstance(neuron_data_dictionary, dict), (
+        "neuron_data_dictionary should be a dictionary of sessions and their corresponding neuron data."
+    )
     assert all(
         field in next(iter(neuron_data_dictionary.values()))
         for field in ["responses_final", "stim_id", "chirp_trigger_times"]
@@ -284,9 +284,9 @@ def get_mb_dataloaders(
     train_chunk_size: Optional[int] = None,
     batch_size: int = 32,
 ):
-    assert isinstance(
-        neuron_data_dictionary, dict
-    ), "neuron_data_dictionary should be a dictionary of sessions and their corresponding neuron data."
+    assert isinstance(neuron_data_dictionary, dict), (
+        "neuron_data_dictionary should be a dictionary of sessions and their corresponding neuron data."
+    )
     assert all(
         field in next(iter(neuron_data_dictionary.values()))
         for field in ["responses_final", "stim_id", "mb_trigger_times"]
@@ -295,9 +295,9 @@ def get_mb_dataloaders(
         "'responses_final', 'stim_id' and 'mb_trigger_times'."
     )
 
-    assert (
-        next(iter(neuron_data_dictionary.values()))["stim_id"] == 2
-    ), "This function only supports moving bar stimuli."
+    assert next(iter(neuron_data_dictionary.values()))["stim_id"] == 2, (
+        "This function only supports moving bar stimuli."
+    )
 
     dataloaders: dict[str, Any] = {"train": {}}
 

--- a/openretina/data_io/hoefling_2024/responses.py
+++ b/openretina/data_io/hoefling_2024/responses.py
@@ -590,7 +590,7 @@ def filter_responses(
         dropped_n_cell_types = original_neuron_count - get_n_neurons(all_rgcs_responses_ct_filtered)
         print_verbose(
             f"Overall, dropped {dropped_n_cell_types} neurons of non-target cell types "
-            f"(-{(dropped_n_cell_types) / original_neuron_count :.2%})."
+            f"(-{(dropped_n_cell_types) / original_neuron_count:.2%})."
         )
         print_verbose(" ------------------------------------ ")
     else:
@@ -658,7 +658,7 @@ def filter_responses(
         f"Final dataset contains {get_n_neurons(all_rgcs_responses)} neurons over {len(all_rgcs_responses)} fields"
     )
     final_n_dropped = original_neuron_count - get_n_neurons(all_rgcs_responses)
-    print(f"Total number of cells dropped: {final_n_dropped} " f"(-{(final_n_dropped) / original_neuron_count :.2%})")
+    print(f"Total number of cells dropped: {final_n_dropped} (-{(final_n_dropped) / original_neuron_count:.2%})")
 
     # Clean up RAM
     del all_rgcs_responses_ct_filtered

--- a/openretina/data_io/maheswaranathan_2023/responses.py
+++ b/openretina/data_io/maheswaranathan_2023/responses.py
@@ -37,9 +37,9 @@ def load_all_responses(
             train_session_data = load_dataset_from_h5(recording_file, f"/train/response/{response_type}")
             test_session_data = load_dataset_from_h5(recording_file, f"/test/response/{response_type}")
 
-            assert (
-                train_session_data.shape[0] == test_session_data.shape[0]
-            ), "Train and test responses should have the same number of neurons."
+            assert train_session_data.shape[0] == test_session_data.shape[0], (
+                "Train and test responses should have the same number of neurons."
+            )
 
             responses_all_sessions[str(session)] = ResponsesTrainTestSplit(
                 train=train_session_data / fr_normalization,

--- a/openretina/insilico/stimulus_optimization/objective.py
+++ b/openretina/insilico/stimulus_optimization/objective.py
@@ -87,7 +87,7 @@ class _ModuleHook:
         assert self.module is module
         self.module_output_tensor = output
         if self.name is not None:
-            print(f"Module hook {self.name} hooked up {type(self.module)=} " f"{self.module_output_tensor.shape=}")
+            print(f"Module hook {self.name} hooked up {type(self.module)=} {self.module_output_tensor.shape=}")
 
     def close(self) -> None:
         self.hook.remove()

--- a/openretina/insilico/stimulus_optimization/regularizer.py
+++ b/openretina/insilico/stimulus_optimization/regularizer.py
@@ -58,9 +58,9 @@ class ChangeNormJointlyClipRangeSeparately(StimulusPostprocessor):
         self._min_max_values = list(min_max_values)
 
     def process(self, x: torch.Tensor) -> torch.Tensor:
-        assert x.shape[1] == len(
-            self._min_max_values
-        ), f"Expected {len(self._min_max_values)} channels in dim 1, got {x.shape=}"
+        assert x.shape[1] == len(self._min_max_values), (
+            f"Expected {len(self._min_max_values)} channels in dim 1, got {x.shape=}"
+        )
 
         if self._norm is not None:
             # Re-normalize

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ omegaconf
 h5py
 opencv-python
 # Type Checks
-ruff
+ruff>=0.9
 mypy>=1.0
 pytest
 types-psutil

--- a/scripts/optimize_mei_autoencoder.py
+++ b/scripts/optimize_mei_autoencoder.py
@@ -33,7 +33,7 @@ def parse_args():
         "--model_path",
         required=True,
         type=str,
-        help="Path to a model, if this is a directory loads an ensemble model, " "otherwise calls torch.load",
+        help="Path to a model, if this is a directory loads an ensemble model, otherwise calls torch.load",
     )
     parser.add_argument("--autoencoder_path", required=True, type=str)
     parser.add_argument("--save_folder", type=str, help="Path were to save outputs", default=".")

--- a/scripts/train_sparse_autoencoder.py
+++ b/scripts/train_sparse_autoencoder.py
@@ -44,7 +44,7 @@ def parse_args():
         "--datasets",
         type=str,
         default="natural",
-        help="Underscore separated list of datasets, " "e.g. 'natural', 'chirp', 'mb', or 'natural_mb'",
+        help="Underscore separated list of datasets, e.g. 'natural', 'chirp', 'mb', or 'natural_mb'",
     )
 
     return parser.parse_args()
@@ -125,8 +125,8 @@ def generate_neuron_activations(
         # Put each example of the batch individually into the list by using extend instead of append
         outputs_model.extend(all_activations.cpu())
         if (batch_no + 1) % 20 == 0:
-            print(f"Generated {batch_no+1} batches")
-    print(f"Generated {len(outputs_model)} examples in {time.time()-time_generation_start:.1f}s")
+            print(f"Generated {batch_no + 1} batches")
+    print(f"Generated {len(outputs_model)} examples in {time.time() - time_generation_start:.1f}s")
     outputs_model_single_tensor = torch.stack(outputs_model)
     # I/O is more efficient on a single tensor
     return outputs_model_single_tensor

--- a/scripts/visualize_model_neurons.py
+++ b/scripts/visualize_model_neurons.py
@@ -41,7 +41,7 @@ def parse_args():
         "--model_id",
         type=int,
         default=-1,
-        help="If >= 0 load the ensemble model with that model_id, " "else use torch.load to load the model",
+        help="If >= 0 load the ensemble model with that model_id, else use torch.load to load the model",
     )
     parser.add_argument("--core_readout_lightning", action="store_true")
     parser.add_argument(


### PR DESCRIPTION
Ruff changed its codestyle slightly with version 0.9: https://github.com/astral-sh/ruff/releases/tag/0.9.0

- The codestyle checks on main failed
- I changed the requirments to ruff>=0.9
- I ran `make fix-all` and commited the changes