### PR TITLE
Adapt visualization script to up to three color channels

### DIFF
--- a/openretina/insilico/stimulus_optimization/regularizer.py
+++ b/openretina/insilico/stimulus_optimization/regularizer.py
@@ -73,7 +73,9 @@ class ChangeNormJointlyClipRangeSeparately(StimulusPostprocessor):
         # Clip
         clipped_array = []
         for i, (min_val, max_val) in enumerate(self._min_max_values):
-            clipped = torch.clamp(renorm[:, i], min=min_val, max=max_val)
+            clipped = renorm[:, i]
+            if min_val is not None or max_val is not None:
+                clipped = torch.clamp(clipped, min=min_val, max=max_val)
             clipped_array.append(clipped)
         result = torch.stack(clipped_array, dim=1)
 

--- a/openretina/insilico/stimulus_optimization/regularizer.py
+++ b/openretina/insilico/stimulus_optimization/regularizer.py
@@ -12,7 +12,7 @@ class StimulusRegularizationLoss:
 class RangeRegularizationLoss(StimulusRegularizationLoss):
     def __init__(
         self,
-        min_max_values: Iterable[tuple[float, float]],
+        min_max_values: Iterable[tuple[float | None, float | None]],
         max_norm: float | None,
         factor: float = 1.0,
     ):
@@ -25,9 +25,10 @@ class RangeRegularizationLoss(StimulusRegularizationLoss):
         loss: torch.Tensor = 0.0  # type: ignore
         for i, (min_val, max_val) in enumerate(self._min_max_values):
             stimulus_i = stimulus[:, i]
-            min_penalty = torch.sum(torch.relu(min_val - stimulus_i))
-            max_penalty = torch.sum(torch.relu(stimulus_i - max_val))
-            loss += min_penalty + max_penalty
+            if min_val is not None:
+                loss += torch.sum(torch.relu(min_val - stimulus_i))
+            if max_val is not None:
+                loss += torch.sum(torch.relu(stimulus_i - max_val))
 
         if self._max_norm is not None:
             # Add a loss such that the norm of the stimulus is lower than max_norm

--- a/openretina/models/core_readout.py
+++ b/openretina/models/core_readout.py
@@ -133,6 +133,25 @@ class BaseCoreReadout(LightningModule):
 
         return core_test_output.shape[1:]  # type: ignore
 
+    @staticmethod
+    def stimulus_shape(file_name: str) -> tuple[int, int, int, int]:
+        """Function to infer the stimulus shape from the file name
+        Note: this is a hack, in the future we can e.g. store the stimulus shape directly.
+        """
+
+        default_time_dim = 80
+        if "hoefling" in file_name:
+            if "high_res" in file_name:
+                return 2, default_time_dim, 72, 64
+            else:
+                return 2, default_time_dim, 18, 16
+        elif "maheswaranathan" in file_name:
+            return 1, default_time_dim, 50, 50
+        elif "karamanlis" in file_name:
+            return 1, default_time_dim, 60, 80
+        else:
+            raise ValueError(f"Could not infer stimulus shape from {file_name=}")
+
 
 class CoreReadout(BaseCoreReadout):
     def __init__(

--- a/openretina/modules/core/base_core.py
+++ b/openretina/modules/core/base_core.py
@@ -35,7 +35,7 @@ class Core(nn.Module):
             ret.append(f"{attr} = {getattr(self, attr)}")
         return s + "|".join(ret) + "]\n"
 
-    def save_weight_visualizations(self) -> None:
+    def save_weight_visualizations(self, folder_path: str) -> None:
         print(f"Save weight visualization of {self.__class__.__name__} not implemented.")
 
 

--- a/openretina/modules/core/base_core.py
+++ b/openretina/modules/core/base_core.py
@@ -35,6 +35,9 @@ class Core(nn.Module):
             ret.append(f"{attr} = {getattr(self, attr)}")
         return s + "|".join(ret) + "]\n"
 
+    def save_weight_visualizations(self) -> None:
+        print(f"Save weight visualization of {self.__class__.__name__} not implemented.")
+
 
 class Core3d(Core):
     def initialize(self) -> None:

--- a/openretina/utils/plotting.py
+++ b/openretina/utils/plotting.py
@@ -176,7 +176,7 @@ def plot_stimulus_composition(
         3: ["red", "green", "blue"],
     }
     color_channel_names_map = {
-        1: ("grey",),
+        1: ("Grey",),
         2: ("Green", "UV"),
         3: ("Red", "Green", "Blue"),
     }
@@ -235,7 +235,7 @@ def plot_stimulus_composition(
     if freq_ax is not None:
         freq_ax.set_xlim(0.0, lowpass_cutoff + 1)
         freq_ax.set_xlabel("Frequency [Hz]")
-        frequencies_str = "/".join([f"x:.1f" for x in weighted_main_freqs])
+        frequencies_str = "/".join([f"{x:.1f}" for x in weighted_main_freqs])
         freq_ax.set_title(
             f"Weighted Frequency: {frequencies_str} Hz"
             f" ({'/'.join(color_channel_names_array)})"

--- a/openretina/utils/plotting.py
+++ b/openretina/utils/plotting.py
@@ -175,7 +175,7 @@ def plot_stimulus_composition(
     color_channel_names_array = color_channel_names_map[num_color_channels]
 
     stimulus_time = np.linspace(0, time_steps / FRAME_RATE_MODEL, time_steps)
-    weighted_main_freqs = [0.0, 0.0]
+    weighted_main_freqs = [0.0] * num_color_channels
     temporal_traces_max = 0.0
 
     temporal_kernels = []
@@ -226,9 +226,10 @@ def plot_stimulus_composition(
     if freq_ax is not None:
         freq_ax.set_xlim(0.0, lowpass_cutoff + 1)
         freq_ax.set_xlabel("Frequency [Hz]")
+        frequencies_str = "/".join([f"x:.1f" for x in weighted_main_freqs])
         freq_ax.set_title(
-            f"Weighted Frequency: {weighted_main_freqs[0]:.1f}/{weighted_main_freqs[1]:.1f} Hz"
-            f" ({color_channel_names_array[0]}/{color_channel_names_array[1]})"
+            f"Weighted Frequency: {frequencies_str} Hz"
+            f" ({'/'.join(color_channel_names_array)})"
         )
 
     if highlight_x_list is not None:

--- a/openretina/utils/plotting.py
+++ b/openretina/utils/plotting.py
@@ -236,10 +236,7 @@ def plot_stimulus_composition(
         freq_ax.set_xlim(0.0, lowpass_cutoff + 1)
         freq_ax.set_xlabel("Frequency [Hz]")
         frequencies_str = "/".join([f"{x:.1f}" for x in weighted_main_freqs])
-        freq_ax.set_title(
-            f"Weighted Frequency: {frequencies_str} Hz"
-            f" ({'/'.join(color_channel_names_array)})"
-        )
+        freq_ax.set_title(f"Weighted Frequency: {frequencies_str} Hz ({'/'.join(color_channel_names_array)})")
 
     if highlight_x_list is not None:
         for x_0_idx, x_1_idx in highlight_x_list:

--- a/openretina/utils/plotting.py
+++ b/openretina/utils/plotting.py
@@ -199,7 +199,7 @@ def plot_stimulus_composition(
             spatial_kernels_with_padding.append(padding)
 
     # Spatial structure
-    spatial_ax.set_title(f"Spatial Component {color_channel_names_array}")
+    spatial_ax.set_title(f"Spatial Component ({'/'.join(color_channel_names_array)})")
     # Create spatial kernel with interleave
 
     spat = np.concatenate(spatial_kernels_with_padding, axis=1)

--- a/scripts/visualize_model_neurons.py
+++ b/scripts/visualize_model_neurons.py
@@ -54,7 +54,7 @@ def parse_args():
         "--stimulus_shape",
         nargs="+",
         type=int,
-        default=[2, 50, 72, 64],
+        default=None,
         help="Stimulus shape: [color_channels, time_dim, height, width",
     )
 
@@ -109,12 +109,8 @@ def main(
     device: str,
     model_id: int,
     is_hoefling_ensemble_model: bool,
-    stimulus_shape: tuple[int, ...],
+    stimulus_shape: tuple[int, ...] | None,
 ) -> None:
-    if len(stimulus_shape) != 4:
-        raise ValueError(f"Invalid stimulus shape, needs to contain 4 integers, but was {stimulus_shape=}")
-    stimulus_shape = (1,) + tuple(stimulus_shape)
-
     model = load_model(
         model_path,
         device=device,
@@ -123,6 +119,12 @@ def main(
         is_hoefling_ensemble_model=is_hoefling_ensemble_model,
     )
     model.eval()
+
+    if stimulus_shape is None:
+        stimulus_shape = model.stimulus_shape(PurePath(model_path).name)
+    if len(stimulus_shape) != 4:
+        raise ValueError(f"Invalid stimulus shape, needs to contain 4 integers, but was {stimulus_shape=}")
+    stimulus_shape = (1,) + tuple(stimulus_shape)
 
     response_reducer = SliceMeanReducer(axis=0, start=10, length=10)
     min_max_values, norm = get_min_max_values_and_norm(stimulus_shape[1])

--- a/scripts/visualize_model_neurons.py
+++ b/scripts/visualize_model_neurons.py
@@ -165,12 +165,14 @@ def main(
             fig_axes_tuple = plt.subplots(2, 2, figsize=(7 * 3, 12))
             axes: np.ndarray[Any, plt.Axes] = fig_axes_tuple[1]  # type: ignore
 
+            highlight_stim_start = stimulus_shape[2] - num_timesteps + response_reducer.start
+            highlight_stim_end = highlight_stim_start + response_reducer.length - 1
             plot_stimulus_composition(
                 stimulus=stimulus_np,
                 temporal_trace_ax=axes[0, 0],
                 freq_ax=axes[0, 1],
                 spatial_ax=axes[1, 0],
-                highlight_x_list=[(40, 49)],
+                highlight_x_list=[(highlight_stim_start, highlight_stim_end)],
             )
             output_folder = f"{save_folder}/{layer_name}"
             os.makedirs(output_folder, exist_ok=True)

--- a/scripts/visualize_model_neurons.py
+++ b/scripts/visualize_model_neurons.py
@@ -79,16 +79,16 @@ def load_model(
     return model
 
 
-def get_min_max_values_and_norm(num_channels: int) -> tuple[tuple, float | None]:
+def get_min_max_values_and_norm(num_channels: int) -> tuple[list[tuple], float | None]:
     if num_channels == 2:
-        min_max_values = (
+        min_max_values = [
             (STIMULUS_RANGE_CONSTRAINTS["x_min_green"], STIMULUS_RANGE_CONSTRAINTS["x_max_green"]),
             (STIMULUS_RANGE_CONSTRAINTS["x_min_uv"], STIMULUS_RANGE_CONSTRAINTS["x_max_uv"]),
-        )
+        ]
         norm = float(STIMULUS_RANGE_CONSTRAINTS["norm"])
         return min_max_values, norm
     else:
-        return (None, None), None
+        return [(None, None)], None
 
 
 def main(

--- a/scripts/visualize_model_neurons.py
+++ b/scripts/visualize_model_neurons.py
@@ -56,7 +56,7 @@ def parse_args():
         type=int,
         default=None,
         help="Stimulus shape: color_channels, time_dim, height, width. "
-             "If not provided will be inferred from the filename",
+        "If not provided will be inferred from the filename",
     )
 
     return parser.parse_args()

--- a/scripts/visualize_model_neurons.py
+++ b/scripts/visualize_model_neurons.py
@@ -55,7 +55,8 @@ def parse_args():
         nargs="+",
         type=int,
         default=None,
-        help="Stimulus shape: [color_channels, time_dim, height, width",
+        help="Stimulus shape: color_channels, time_dim, height, width. "
+             "If not provided will be inferred from the filename",
     )
 
     return parser.parse_args()


### PR DESCRIPTION
Works for all pretrained models now. Example command:
```
./scripts/visualize_model_neurons.py --model_path models/hoefling_2024_GRU_high_res_model.ckpt --save_folder vis/hoefling_2024_GRU_high_res_model
```

Changes:
- Make plotting and video generation work for grey-scale videos
- Optionally infer stimulus shape from filename [1]
- Update visualize_model_neurons script to work with all models

[1] It might be useful to store the input shape in the CoreReadoutModel, too (we currently pass it to the constructor, but do not store it their). If doing so, we would not have to pass it to the visualize_model_neurons script.