### PR TITLE
Dev: Make numpy 2.0 work

### DIFF
--- a/openretina/data_io/artificial_stimuli.py
+++ b/openretina/data_io/artificial_stimuli.py
@@ -27,7 +27,7 @@ def normalize_stimulus(stimulus: np.ndarray) -> np.ndarray:
 
 def discretize_triggers(trigger_times: np.ndarray, frame_rate: int = _DEFAULT_FRAME_RATE) -> list[int]:
     assert len(trigger_times.shape) == 1, "trigger_times should be one dimensional"
-    discrete_trigger_times = (trigger_times * frame_rate).astype(int).tolist()
+    discrete_trigger_times: list[int] = (trigger_times * frame_rate).astype(int).tolist()  # type: ignore
     return discrete_trigger_times
 
 

--- a/openretina/data_io/base_dataloader.py
+++ b/openretina/data_io/base_dataloader.py
@@ -280,7 +280,7 @@ def handle_missing_start_indices(
         return [0]
 
     interval = get_chunking_interval(split)
-    return np.arange(0, movie_length, interval).tolist()
+    return np.arange(0, movie_length, interval).tolist()  # type: ignore
 
 
 def get_movie_dataloader(

--- a/openretina/data_io/hoefling_2024/stimuli.py
+++ b/openretina/data_io/hoefling_2024/stimuli.py
@@ -34,15 +34,13 @@ def apply_random_sequences(
     }
 
     for sequence_index in range(random_sequences.shape[1]):
-        k = 0
         reordered_movie = torch.zeros_like(movie_train_subset)
-        for clip_idx in random_sequences[:, sequence_index]:
-            if clip_idx in val_clip_idx:
-                continue
+        # explicitly cast to int, as random_sequences is a np.uint8 which is prone to overflow.
+        clip_indices = [int(idx) for idx in random_sequences[:, sequence_index] if idx not in val_clip_idx]
+        for k, clip_idx in enumerate(clip_indices):
             reordered_movie[:, k * clip_length : (k + 1) * clip_length, ...] = movie_train[
                 :, clip_idx * clip_length : (clip_idx + 1) * clip_length, ...
             ]
-            k += 1
         movies["right"]["train"][sequence_index] = reordered_movie  # type: ignore
         movies["left"]["train"][sequence_index] = torch.flip(reordered_movie, [-1])  # type: ignore
 

--- a/openretina/utils/h5_handling.py
+++ b/openretina/utils/h5_handling.py
@@ -149,7 +149,7 @@ def load_dataset_from_h5(file_path, dataset_path: str) -> np.ndarray:
     """
     with h5.File(file_path, "r") as file:
         if dataset_path in file:
-            data = file[dataset_path][()]  # type: ignore
-            return np.asarray(data)
+            data = np.array(file[dataset_path][()], dtype=np.float32)  # explicit conversion for numpy 2.0
+            return data
         else:
             raise FileNotFoundError(f"Dataset path {dataset_path} not found in the file.")

--- a/openretina/utils/h5_handling.py
+++ b/openretina/utils/h5_handling.py
@@ -149,7 +149,7 @@ def load_dataset_from_h5(file_path, dataset_path: str) -> np.ndarray:
     """
     with h5.File(file_path, "r") as file:
         if dataset_path in file:
-            data = np.array(file[dataset_path][()], dtype=np.float32)  # explicit conversion for numpy 2.0
-            return data
+            data = file[dataset_path][()]  # type: ignore
+            return np.asarray(data)
         else:
             raise FileNotFoundError(f"Dataset path {dataset_path} not found in the file.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 IPython
 jaxtyping
 matplotlib
-numpy<2.0  # h5py loading does not work with 2.0
+numpy
 pandas
 seaborn
 scipy


### PR DESCRIPTION
Fixes: https://github.com/open-retina/open-retina/issues/48

The main issue was a overflow of a variable that had type np.uint8. I also had to add to `type: ignore` statements, as the type annotations seem to be slightly off in numpy==2.0?