### PR TITLE
Dev: Fix types after pytorch 2.6 was released

### DIFF
--- a/openretina/models/core_readout.py
+++ b/openretina/models/core_readout.py
@@ -63,7 +63,7 @@ class BaseCoreReadout(LightningModule):
         model_output = self.forward(data_point.inputs, session_id)
         loss = self.loss.forward(model_output, data_point.targets)
         regularization_loss_core = self.core.regularizer()
-        regularization_loss_readout = self.readout.regularizer(session_id)
+        regularization_loss_readout = self.readout.regularizer(session_id)  # type: ignore
         total_loss = loss + regularization_loss_core + regularization_loss_readout
         correlation = -self.correlation_loss.forward(model_output, data_point.targets)
 
@@ -80,7 +80,7 @@ class BaseCoreReadout(LightningModule):
         model_output = self.forward(data_point.inputs, session_id)
         loss = self.loss.forward(model_output, data_point.targets) / sum(model_output.shape)
         regularization_loss_core = self.core.regularizer()
-        regularization_loss_readout = self.readout.regularizer(session_id)
+        regularization_loss_readout = self.readout.regularizer(session_id)  # type: ignore
         total_loss = loss + regularization_loss_core + regularization_loss_readout
         correlation = -self.correlation_loss.forward(model_output, data_point.targets)
 
@@ -132,7 +132,7 @@ class BaseCoreReadout(LightningModule):
 
     def save_weight_visualizations(self, folder_path: str, file_format: str = "jpg") -> None:
         self.core.save_weight_visualizations(os.path.join(folder_path, "weights_core"), file_format)
-        self.readout.save_weight_visualizations(os.path.join(folder_path, "weights_readout"), file_format)
+        self.readout.save_weight_visualizations(os.path.join(folder_path, "weights_readout"), file_format)  # type: ignore
 
     def compute_readout_input_shape(
         self, core_in_shape: tuple[int, int, int, int], core: Core

--- a/openretina/models/sparse_autoencoder.py
+++ b/openretina/models/sparse_autoencoder.py
@@ -158,7 +158,7 @@ class AutoencoderWithModel(nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         model_outputs: list[torch.Tensor] = []
-        for key in self.model.readout_keys():
+        for key in self.model.readout_keys():  # type: ignore
             out = self.model.forward(x, key)
             model_outputs.append(out)
         activations = torch.cat(model_outputs, dim=-1)

--- a/openretina/modules/core/base_core.py
+++ b/openretina/modules/core/base_core.py
@@ -175,7 +175,7 @@ class SimpleCoreWrapper(Core):
 
     def plot_weight_visualization(self, layer: int, in_channel: int, out_channel: int) -> plt.Figure:
         if layer >= len(self.features):
-            raise ValueError(f"Requested layer {layer}, but only {len(self.core.features)} layers present.")
+            raise ValueError(f"Requested layer {layer}, but only {len(self.features)} layers present.")
         conv_obj = self.features[layer].conv
         fig = conv_obj.plot_weights(in_channel, out_channel)
         return fig

--- a/openretina/modules/layers/convolutions.py
+++ b/openretina/modules/layers/convolutions.py
@@ -102,8 +102,8 @@ class TorchSTSeparableConv3D(nn.Module):
             log_speed = getattr(self, "_".join(["log_speed", data_key]))
 
         space_conv = self.space_conv(x)
-
-        return torch.exp(log_speed) * self.time_conv(space_conv)
+        exp_log_speed = torch.exp(log_speed)  # type: ignore
+        return exp_log_speed * self.time_conv(space_conv)
 
 
 class TimeIndependentConv3D(nn.Module):

--- a/openretina/modules/layers/regularizers.py
+++ b/openretina/modules/layers/regularizers.py
@@ -108,7 +108,7 @@ class Laplace(nn.Module):
             raise ValueError(f"Unsupported filter size {filter_size}")
 
         self.register_buffer("filter", torch.from_numpy(kernel))
-        self.padding_size = self.filter.shape[-1] // 2 if padding is None else padding
+        self.padding_size = kernel.shape[-1] // 2 if padding is None else padding
 
     def forward(self, x):
         return F.conv2d(x, self.filter, bias=None, padding=self.padding_size)
@@ -118,10 +118,10 @@ class Laplace1d(torch.nn.Module):
     def __init__(self, padding: int | None):
         super().__init__()
         self.register_buffer("filter", torch.from_numpy(LAPLACE_1D))
-        self.padding_size = self.filter.shape[-1] // 2 if padding is None else padding
+        self.padding_size = LAPLACE_1D.shape[-1] // 2 if padding is None else padding
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return F.conv1d(x, self.filter, bias=None, padding=self.padding_size)
+        return F.conv1d(x, self.filter, bias=None, padding=self.padding_size)  # type: ignore
 
 
 class TimeLaplaceL23dnorm(nn.Module):

--- a/openretina/modules/readout/multi_readout.py
+++ b/openretina/modules/readout/multi_readout.py
@@ -72,7 +72,7 @@ class MultiGaussianReadoutWrapper(nn.ModuleDict):
         for key in self.readout_keys():
             readout_folder = os.path.join(folder_path, key)
             os.makedirs(readout_folder, exist_ok=True)
-            self._modules[key].save_weight_visualizations(readout_folder)
+            self._modules[key].save_weight_visualizations(readout_folder)  # type: ignore
 
     @property
     def sessions(self) -> list[str]:


### PR DESCRIPTION
Pytorch 2.6 was released 2 days ago: https://pytorch.org/blog/pytorch2-6/

This apparently changed the types a bit, the patterns I encountered are that buffers are typed differently (I think it was `torch.Tensor | torch.nn.Module`) and that torch.nn.Module now is considered in types.

I fixed most type annotations inconsistencies with adding `# type: ignore` for now.
I fixed a genuine error in the description of a ValueError.