### PR TITLE
Cmd options with dashes instead of underscore, set data.root_dir to OPENRETINA_CACHE_DIR if not provided

### DIFF
--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -20,6 +20,12 @@ jobs:
           python-version: "3.10"
           cache: 'pip'
 
+      - name: Load Openretina_cache
+        uses: actions/cache@v4
+        with:
+          path: ~/openretina_cache
+          key: openretina_cache_v1
+
       - name: Install openretina with dependencies
         run: |
           pip install --upgrade pip

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -20,7 +20,7 @@ jobs:
           python-version: "3.10"
           cache: 'pip'
 
-      - name: Load Openretina_cache
+      - name: Load openretina_cache
         uses: actions/cache@v4
         with:
           path: ~/openretina_cache

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -20,6 +20,12 @@ jobs:
           python-version: "3.10"
           cache: 'pip'
 
+      - name: Load openretina_cache
+        uses: actions/cache@v4
+        with:
+          path: ~/openretina_cache
+          key: openretina_cache_v1
+
       - name: Install openretina with dependencies
         run: |
           pip install --upgrade pip

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ fix-all: fix-codestyle fix-formatting
 
 test-corereadout:
 	openretina train --config-path configs --config-name hoefling_2024_core_readout_low_res \
-	data.root_dir=./openretina_cache_folder data.responses_path=https://gin.g-node.org/teulerlab/open-retina/raw/master/responses/eulerlab/rgc_natsim_subset_only_naturalspikes_2024-08-14.h5 \
+	data.responses_path=https://gin.g-node.org/teulerlab/open-retina/raw/master/responses/eulerlab/rgc_natsim_subset_only_naturalspikes_2024-08-14.h5 \
 	exp_name=test_hoefling_2024_low_res \
 	+trainer.limit_train_batches=1 trainer.max_epochs=1 +trainer.limit_val_batches=1 +trainer.limit_test_batches=1 dataloader.batch_size=2
 

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,6 @@ fix-all: fix-codestyle fix-formatting
 test-corereadout:
 	openretina train --config-path configs --config-name hoefling_2024_core_readout_low_res \
 	data.responses_path=https://gin.g-node.org/teulerlab/open-retina/raw/master/responses/eulerlab/rgc_natsim_subset_only_naturalspikes_2024-08-14.h5 \
-	exp_name=test_hoefling_2024_low_res \
+	data.output_dir=exp exp_name=test_hoefling_2024_low_res \
 	+trainer.limit_train_batches=1 trainer.max_epochs=1 +trainer.limit_val_batches=1 +trainer.limit_test_batches=1 dataloader.batch_size=2
 

--- a/openretina/cli/openretina.py
+++ b/openretina/cli/openretina.py
@@ -7,6 +7,7 @@ import hydra
 from omegaconf import DictConfig
 
 from openretina.cli import visualize_model_neurons
+from openretina.utils.file_utils import OPENRETINA_CACHE_DIRECTORY
 
 
 def get_config_path(config_path: str | None):
@@ -27,6 +28,9 @@ class HydraRunner:
 
     @staticmethod
     def train(config_path, args):
+        # check if data.root if in argument, otherwise set it to openretina cache dir
+        if not any("data.root_dir" in x for x in args):
+            args.append(f"data.root_dir='{OPENRETINA_CACHE_DIRECTORY}'")
         # Modify sys.argv to work with Hydra
         sys.argv = [sys.argv[0]] + args
 

--- a/openretina/cli/openretina.py
+++ b/openretina/cli/openretina.py
@@ -10,7 +10,7 @@ from openretina.cli import visualize_model_neurons
 from openretina.utils.file_utils import OPENRETINA_CACHE_DIRECTORY
 
 
-def get_config_path(config_path: str | None):
+def get_config_path(config_path: str | None) -> str:
     """Get the absolute path to the configs directory"""
     if config_path is None:
         path = str(Path(__file__).parent.parent.parent / "configs")
@@ -27,7 +27,7 @@ class HydraRunner:
     """Wrapper class to run Hydra commands"""
 
     @staticmethod
-    def train(config_path, args):
+    def train(config_path: str, args: list[str]) -> None:
         # check if data.root if in argument, otherwise set it to openretina cache dir
         if not any("data.root_dir" in x for x in args):
             args.append(f"data.root_dir='{OPENRETINA_CACHE_DIRECTORY}'")
@@ -47,7 +47,7 @@ class HydraRunner:
         _train()
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(description="OpenRetina CLI")
     subparsers = parser.add_subparsers(dest="command", help="Available commands")
 

--- a/openretina/cli/visualize_model_neurons.py
+++ b/openretina/cli/visualize_model_neurons.py
@@ -31,11 +31,11 @@ def add_parser_arguments(parser: argparse.ArgumentParser):
     )
 
     group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument("--model_path", type=str)
-    group.add_argument("--is_hoefling_ensemble_model", action="store_true")
+    group.add_argument("--model-path", type=str)
+    group.add_argument("--is-hoefling-ensemble-model", action="store_true")
 
     parser.add_argument(
-        "--save_folder",
+        "--save-folder",
         type=str,
         required=True,
         help="Path were to save outputs",
@@ -44,19 +44,19 @@ def add_parser_arguments(parser: argparse.ArgumentParser):
         "--device", type=str, choices=["cuda", "cpu"], default="cuda" if torch.cuda.is_available() else "cpu"
     )
     parser.add_argument(
-        "--model_id",
+        "--model-id",
         type=int,
         default=-1,
         help="If >= 0 load the ensemble model with that model_id, else use torch.load to load the model",
     )
     parser.add_argument(
-        "--time_steps_stimulus",
+        "--time-steps-stimulus",
         type=int,
         default=50,
         help="The time steps used in the stimulus to optimize",
     )
     parser.add_argument(
-        "--image_file_format", type=str, default="jpg", help="File format to save the visualization plots in"
+        "--image-file-format", type=str, default="jpg", help="File format to save the visualization plots in"
     )
 
 


### PR DESCRIPTION
- Dashes instead of underscores is recommended by [GNU](https://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html):
```
Option names are typically one to three words long, with hyphens to separate words.
```
- I think data.root_dir=OPENRETINA_CACHE_DIR is a reasonable option, as pretrained models are also downloaded to that directory. We can also include an easier example in the quickstart section then.
- Cache `~/openretina_cache` in the end-to-end tests and in unit-tests. This results in a speed up of the tests, the end to end tests now only need 2 minutes to run.