### PR TITLE
Dev: require huggingface_hub>=0.25

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,6 @@ h5py
 opencv-python-headless
 imageio>=2.36
 moviepy>=2.0.0
-huggingface_hub
+huggingface_hub>=0.25  # due to EntryNotFound import
 jupyter
 ipywidgets


### PR DESCRIPTION
In version below that import 'EntryNotFoundError' from 'huggingface_hub.errors' does not work.