### PR TITLE
Bugfix: actually use torch conv3d, additonally pass convolution_type from config

### DIFF
--- a/configs/model/GRU_core_readout.yaml
+++ b/configs/model/GRU_core_readout.yaml
@@ -16,6 +16,7 @@ core_hidden_padding: [0, 2, 2]
 core_use_gru: false
 core_use_projections: true
 batch_adaptation: false
+convolution_type: "custom_separable"
 
 # GRU-specific arguments. GRU is applied before the readout.
 core_gru_kwargs:

--- a/configs/model/base_core_readout.yaml
+++ b/configs/model/base_core_readout.yaml
@@ -14,6 +14,7 @@ core_input_padding: 0
 core_hidden_padding: [0, 2, 2]
 maxpool_every_n_layers: null
 downsample_input_kernel_size: null
+convolution_type: "custom_separable"
 
 # readout
 n_neurons_dict: ??? # Required for readout init. Set dynamically in scripts/train.py based on loaded sessions.

--- a/configs/model/core_gaussian_readout.yaml
+++ b/configs/model/core_gaussian_readout.yaml
@@ -14,6 +14,7 @@ core_input_padding: false
 core_hidden_padding: false
 maxpool_every_n_layers: null
 downsample_input_kernel_size: null
+convolution_type: "full"
 
 # readout
 n_neurons_dict: ??? # Required for readout init. Set dynamically in scripts/train.py based on loaded sessions.

--- a/configs/model/core_gaussian_readout.yaml
+++ b/configs/model/core_gaussian_readout.yaml
@@ -14,7 +14,7 @@ core_input_padding: false
 core_hidden_padding: false
 maxpool_every_n_layers: null
 downsample_input_kernel_size: null
-convolution_type: "full"
+convolution_type: "separable"
 
 # readout
 n_neurons_dict: ??? # Required for readout init. Set dynamically in scripts/train.py based on loaded sessions.

--- a/openretina/models/core_readout.py
+++ b/openretina/models/core_readout.py
@@ -358,6 +358,7 @@ class CoreGaussianReadout(BaseCoreReadout):
         dropout_rate: float = 0.0,
         maxpool_every_n_layers: Optional[int] = None,
         downsample_input_kernel_size: Optional[tuple[int, int, int]] = None,
+        convolution_type: str = "full",
         data_info: dict[str, Any] | None = None,
     ):
         core = SimpleCoreWrapper(
@@ -374,7 +375,7 @@ class CoreGaussianReadout(BaseCoreReadout):
             downsample_input_kernel_size=downsample_input_kernel_size,
             input_padding=core_input_padding,
             hidden_padding=core_hidden_padding,
-            convolution_type="torch",
+            convolution_type=convolution_type,
         )
 
         in_shape_readout = self.compute_readout_input_shape(in_shape, core)

--- a/openretina/models/core_readout.py
+++ b/openretina/models/core_readout.py
@@ -147,7 +147,8 @@ class BaseCoreReadout(LightningModule):
         device = next(core.parameters()).device
 
         with torch.no_grad():
-            core_test_output = core.forward(torch.zeros((1,) + tuple(core_in_shape)), device=device)
+            stimulus = torch.zeros((1,) + tuple(core_in_shape), device=device)
+            core_test_output = core.forward(stimulus)
 
         return core_test_output.shape[1:]  # type: ignore
 

--- a/openretina/models/core_readout.py
+++ b/openretina/models/core_readout.py
@@ -144,10 +144,10 @@ class BaseCoreReadout(LightningModule):
         self, core_in_shape: tuple[int, int, int, int], core: Core
     ) -> tuple[int, int, int, int]:
         # Use the same device as the core's parameters to avoid potential errors at init.
-        # device = next(core.parameters()).device
+        device = next(core.parameters()).device
 
         with torch.no_grad():
-            core_test_output = core.forward(torch.zeros((1,) + tuple(core_in_shape)))
+            core_test_output = core.forward(torch.zeros((1,) + tuple(core_in_shape)), device=device)
 
         return core_test_output.shape[1:]  # type: ignore
 

--- a/openretina/models/core_readout.py
+++ b/openretina/models/core_readout.py
@@ -200,6 +200,7 @@ class CoreReadout(BaseCoreReadout):
         dropout_rate: float = 0.0,
         maxpool_every_n_layers: Optional[int] = None,
         downsample_input_kernel_size: Optional[tuple[int, int, int]] = None,
+        convolution_type: str = "custom_separable",
         data_info: dict[str, Any] | None = None,
     ):
         core = SimpleCoreWrapper(
@@ -216,6 +217,7 @@ class CoreReadout(BaseCoreReadout):
             downsample_input_kernel_size=downsample_input_kernel_size,
             input_padding=core_input_padding,
             hidden_padding=core_hidden_padding,
+            convolution_type=convolution_type,
         )
 
         # Run one forward pass to determine output shape of core
@@ -269,6 +271,7 @@ class GRUCoreReadout(BaseCoreReadout):
         batch_adaptation: bool = False,
         learning_rate: float = 0.01,
         core_gru_kwargs: Optional[dict] = None,
+        convolution_type: str = "custom_separable",
         data_info: dict[str, Any] | None = None,
     ):
         core = ConvGRUCore(  # type: ignore
@@ -292,7 +295,7 @@ class GRUCoreReadout(BaseCoreReadout):
             batch_adaptation=batch_adaptation,
             use_avg_reg=False,
             nonlinearity="ELU",
-            conv_type="custom_separable",
+            conv_type=convolution_type,
             use_gru=core_use_gru,
             use_projections=core_use_projections,
             gru_kwargs=core_gru_kwargs,

--- a/openretina/models/linear_nonlinear.py
+++ b/openretina/models/linear_nonlinear.py
@@ -12,7 +12,7 @@ from openretina.models.core_readout import BaseCoreReadout
 from openretina.modules.core.base_core import DummyCore
 from openretina.modules.layers import regularizers
 from openretina.modules.losses import CorrelationLoss3d, PoissonLoss3d
-from openretina.modules.nonlinearities import parametrized_softplus
+from openretina.modules.nonlinearities import ParametrizedSoftplus
 from openretina.modules.readout.multi_readout import MultiReadoutBase
 
 
@@ -158,7 +158,7 @@ class SingleCellSeparatedLNP(LightningModule):
         self.in_channels = in_shape[0]
         self.n_neurons = 1
         self.nonlinearity = (
-            parametrized_softplus() if nonlinearity == "parametrized_softplus" else F.__dict__[nonlinearity]
+            ParametrizedSoftplus() if nonlinearity == "parametrized_softplus" else F.__dict__[nonlinearity]
         )
         self.fit_gaussian = fit_gaussian
         self.space_conv = nn.Conv3d(

--- a/openretina/modules/core/base_core.py
+++ b/openretina/modules/core/base_core.py
@@ -180,7 +180,10 @@ class SimpleCoreWrapper(Core):
             results = [temporal_smoothing(x.conv.sin_weights, x.conv.cos_weights) for x in self.features]
             return torch.sum(torch.stack(results))
         else:
-            raise ValueError(f"Temporal smoothness not supported for {self.convolution_type=}")
+            raise ValueError(
+            f"Temporal smoothness not supported for {self.convolution_type=}. "
+            "Set the temporal smoothness regularisation weight to 0 to still use this conv type."
+            )
 
     def group_sparsity_0(self) -> torch.Tensor:
         result_array = []

--- a/openretina/modules/core/base_core.py
+++ b/openretina/modules/core/base_core.py
@@ -69,7 +69,7 @@ class SimpleCoreWrapper(Core):
         downsample_input_kernel_size: tuple[int, int, int] | None = None,
         input_padding: bool | int | str | tuple[int, int, int] = False,
         hidden_padding: bool | int | str | tuple[int, int, int] = True,
-        convolution_type: str = "sin_cos",
+        convolution_type: str = "custom_separable",
     ):
         # Input validation
         if len(channels) < 2:
@@ -120,6 +120,7 @@ class SimpleCoreWrapper(Core):
             else:
                 padding = padding_to_use
 
+            breakpoint()
             conv_class = get_conv_class(self.convolution_type)
             layer["conv"] = conv_class(
                 num_in_channels,

--- a/openretina/modules/core/base_core.py
+++ b/openretina/modules/core/base_core.py
@@ -120,7 +120,6 @@ class SimpleCoreWrapper(Core):
             else:
                 padding = padding_to_use
 
-            breakpoint()
             conv_class = get_conv_class(self.convolution_type)
             layer["conv"] = conv_class(
                 num_in_channels,

--- a/openretina/modules/core/base_core.py
+++ b/openretina/modules/core/base_core.py
@@ -181,8 +181,8 @@ class SimpleCoreWrapper(Core):
             return torch.sum(torch.stack(results))
         else:
             raise ValueError(
-            f"Temporal smoothness not supported for {self.convolution_type=}. "
-            "Set the temporal smoothness regularisation weight to 0 to still use this conv type."
+                f"Temporal smoothness not supported for {self.convolution_type=}. "
+                "Set the temporal smoothness regularization weight to 0.0 to still use this conv type."
             )
 
     def group_sparsity_0(self) -> torch.Tensor:

--- a/openretina/modules/core/base_core.py
+++ b/openretina/modules/core/base_core.py
@@ -7,7 +7,7 @@ import torch.nn as nn
 from matplotlib import pyplot as plt
 
 from openretina.modules.layers import FlatLaplaceL23dnorm
-from openretina.modules.layers.convolutions import STSeparableBatchConv3d, TorchSTSeparableConv3D
+from openretina.modules.layers.convolutions import get_conv_class
 from openretina.modules.layers.regularizers import Laplace1d
 from openretina.modules.layers.scaling import Bias3DLayer
 
@@ -112,7 +112,7 @@ class SimpleCoreWrapper(Core):
         for layer_id, (num_in_channels, num_out_channels) in enumerate(zip(channels[:-1], channels[1:], strict=True)):
             layer: dict[str, torch.nn.Module] = OrderedDict()
             padding_to_use = input_padding if layer_id == 0 else hidden_padding
-            # explictily check against bools as the type can also be an int or a tuple
+            # explicitly check against bools as the type can also be an int or a tuple
             if padding_to_use is True:
                 padding: str | int | tuple[int, int, int] = "same"
             elif padding_to_use is False:
@@ -120,40 +120,25 @@ class SimpleCoreWrapper(Core):
             else:
                 padding = padding_to_use
 
-            if self.convolution_type == "sin_cos":
-                layer["conv"] = STSeparableBatchConv3d(
-                    num_in_channels,
-                    num_out_channels,
-                    log_speed_dict={},
-                    temporal_kernel_size=temporal_kernel_sizes[layer_id],
-                    spatial_kernel_size=spatial_kernel_sizes[layer_id],
-                    bias=False,
-                    padding=padding,
-                )
+            conv_class = get_conv_class(self.convolution_type)
+            layer["conv"] = conv_class(
+                num_in_channels,
+                num_out_channels,
+                log_speed_dict={},
+                temporal_kernel_size=temporal_kernel_sizes[layer_id],
+                spatial_kernel_size=spatial_kernel_sizes[layer_id],
+                bias=False,
+                padding=padding,
+            )
 
-                layer["norm"] = torch.nn.BatchNorm3d(num_out_channels, momentum=0.1, affine=True)
-                layer["bias"] = Bias3DLayer(num_out_channels)
-                layer["nonlin"] = torch.nn.ELU()
-                if dropout_rate > 0.0:
-                    layer["dropout"] = torch.nn.Dropout3d(p=dropout_rate)
-                if maxpool_every_n_layers is not None and (layer_id % maxpool_every_n_layers) == 0:
-                    layer["pool"] = torch.nn.MaxPool3d((1, 2, 2))
-                self.features.add_module(f"layer{layer_id}", torch.nn.Sequential(layer))  # type: ignore
-
-            elif self.convolution_type == "torch":
-                layer["conv"] = TorchSTSeparableConv3D(
-                    num_in_channels,
-                    num_out_channels,
-                    log_speed_dict={},
-                    temporal_kernel_size=temporal_kernel_sizes[layer_id],
-                    spatial_kernel_size=spatial_kernel_sizes[layer_id],
-                    bias=False,
-                    padding=padding,
-                )
-            else:
-                raise ValueError(
-                    f"Unknown type {convolution_type}. Supported convolution types are 'sin_cos' and 'torch'."
-                )
+            layer["norm"] = torch.nn.BatchNorm3d(num_out_channels, momentum=0.1, affine=True)
+            layer["bias"] = Bias3DLayer(num_out_channels)
+            layer["nonlin"] = torch.nn.ELU()
+            if dropout_rate > 0.0:
+                layer["dropout"] = torch.nn.Dropout3d(p=dropout_rate)
+            if maxpool_every_n_layers is not None and (layer_id % maxpool_every_n_layers) == 0:
+                layer["pool"] = torch.nn.MaxPool3d((1, 2, 2))
+            self.features.add_module(f"layer{layer_id}", torch.nn.Sequential(layer))  # type: ignore
 
     def forward(self, input_: torch.Tensor) -> torch.Tensor:
         if self._downsample_input_kernel_size is not None:
@@ -173,7 +158,7 @@ class SimpleCoreWrapper(Core):
         )
 
     def temporal_smoothness(self) -> torch.Tensor:
-        if self.convolution_type == "torch":
+        if self.convolution_type == "separable":
             return self.temporal_laplace()
         else:
             results = [temporal_smoothing(x.conv.sin_weights, x.conv.cos_weights) for x in self.features]

--- a/openretina/modules/core/base_core.py
+++ b/openretina/modules/core/base_core.py
@@ -176,9 +176,11 @@ class SimpleCoreWrapper(Core):
     def temporal_smoothness(self) -> torch.Tensor:
         if self.convolution_type == "separable":
             return self.temporal_laplace()
-        else:
+        elif self.convolution_type == "custom_separable":
             results = [temporal_smoothing(x.conv.sin_weights, x.conv.cos_weights) for x in self.features]
             return torch.sum(torch.stack(results))
+        else:
+            raise ValueError(f"Temporal smoothness not supported for {self.convolution_type=}")
 
     def group_sparsity_0(self) -> torch.Tensor:
         result_array = []

--- a/openretina/modules/core/gru_core.py
+++ b/openretina/modules/core/gru_core.py
@@ -9,10 +9,9 @@ from openretina.modules.core.base_core import Core3d
 from openretina.modules.layers import Bias3DLayer, Scale2DLayer, Scale3DLayer
 from openretina.modules.layers.convolutions import (
     STSeparableBatchConv3d,
-    TimeIndependentConv3D,
     TorchFullConv3D,
-    TorchSTSeparableConv3D,
     compute_temporal_kernel,
+    get_conv_class,
     temporal_smoothing,
 )
 from openretina.modules.layers.gru import GRU_Module
@@ -56,7 +55,7 @@ class ConvGRUCore(Core3d, nn.Module):
         self._input_weights_regularizer_temporal = TimeLaplaceL23dnorm(padding=laplace_padding)
 
         # Get convolution class
-        self.conv_class = self.get_conv_class(conv_type)
+        self.conv_class = get_conv_class(conv_type)
 
         if n_neurons_dict is None:
             n_neurons_dict = {}
@@ -127,18 +126,6 @@ class ConvGRUCore(Core3d, nn.Module):
             )
 
         return input_
-
-    def get_conv_class(self, conv_type: str) -> type[nn.Module]:
-        if conv_type == "separable":
-            return TorchSTSeparableConv3D
-        elif conv_type == "custom_separable":
-            return STSeparableBatchConv3d
-        elif conv_type == "full":
-            return TorchFullConv3D
-        elif conv_type == "time_independent":
-            return TimeIndependentConv3D
-        else:
-            raise ValueError(f"Un-implemented conv_type {conv_type}")
 
     def calculate_padding(self, input_padding, hidden_padding, spatial_kernel_size):
         if input_padding:

--- a/openretina/modules/layers/convolutions.py
+++ b/openretina/modules/layers/convolutions.py
@@ -92,7 +92,7 @@ class TorchSTSeparableConv3D(nn.Module):
             out_channels, out_channels, (temporal_kernel_size, 1, 1), stride=stride, padding=padding, bias=bias
         )
 
-    def forward(self, input_: torch.Tensor) -> torch.Tensor:
+    def forward(self, input_: torch.Tensor | tuple[torch.Tensor, str | None]) -> torch.Tensor:
         if type(input_) is torch.Tensor:
             x = input_
             data_key: str | None = None

--- a/openretina/modules/layers/convolutions.py
+++ b/openretina/modules/layers/convolutions.py
@@ -42,8 +42,12 @@ class TorchFullConv3D(nn.Module):
             bias=bias,
         )
 
-    def forward(self, input_: torch.Tensor) -> torch.Tensor:
-        x, data_key = input_
+    def forward(self, input_: torch.Tensor | tuple[torch.Tensor, str]) -> torch.Tensor:
+        if type(input_) is torch.Tensor:
+            x = input_
+            data_key: str | None = None
+        else:
+            x, data_key = input_
 
         # Compute temporal kernel based on the provided data key
         # TODO implement log speed use in full conv
@@ -142,7 +146,11 @@ class TimeIndependentConv3D(nn.Module):
         )
 
     def forward(self, input_):
-        x, data_key = input_
+        if type(input_) is torch.Tensor:
+            x = input_
+            data_key: str | None = None
+        else:
+            x, data_key = input_
         return self.conv(x)
 
 

--- a/openretina/modules/layers/convolutions.py
+++ b/openretina/modules/layers/convolutions.py
@@ -440,3 +440,16 @@ def temporal_smoothing(sin: torch.Tensor, cos: torch.Tensor) -> torch.Tensor:
     reg = torch.sum((smoother * sin) ** 2) / F
     reg += torch.sum((smoother * cos) ** 2) / F
     return reg
+
+
+def get_conv_class(conv_type: str) -> type[nn.Module]:
+    if conv_type == "separable":
+        return TorchSTSeparableConv3D
+    elif conv_type == "custom_separable":
+        return STSeparableBatchConv3d
+    elif conv_type == "full":
+        return TorchFullConv3D
+    elif conv_type == "time_independent":
+        return TimeIndependentConv3D
+    else:
+        raise ValueError(f"Un-implemented conv_type {conv_type}")

--- a/openretina/modules/nonlinearities.py
+++ b/openretina/modules/nonlinearities.py
@@ -13,7 +13,7 @@ class ParametrizedELU(nn.Module):
         return torch.where(x > 0, self.c * x, self.a * (torch.exp(x / self.b) - 1))
 
 
-class parametrized_softplus(nn.Module):
+class ParametrizedSoftplus(nn.Module):
     def __init__(self, a=1.0, b=0.0, w=1.0, learn_a=False):
         super().__init__()
         if learn_a:


### PR DESCRIPTION
- Fixed bug that lead to an empty core for the convolution_type == "torch" (this was introduced in https://github.com/open-retina/open-retina/pull/145)
- Unified convolution type names by using get_conv_type for GRU and conv models
- Few consistency changes
- Exposed convolution_type in the config.