### PR TITLE
Dev: close zip file before unlinking it

### DIFF
--- a/openretina/utils/file_utils.py
+++ b/openretina/utils/file_utils.py
@@ -40,12 +40,14 @@ def unzip_and_cleanup(zip_path: Path) -> Path:
             extracted_file = zip_path.parent / zip_contents[0]
             zf.extract(zip_contents[0], zip_path.parent)
             LOGGER.info(f"Extracted single file to {extracted_file.resolve()}.")
-            target_path = extracted_file  # the target_path we return is the path of the extracted file
+            # the target_path we return is the path of the extracted file
+            target_path = extracted_file
         else:
             # Check if zip contains a single folder with the same name as the zip
             top_level_items = {Path(item).parts[0] for item in zip_contents}  # Get unique top-level names
             if len(top_level_items) == 1 and next(iter(top_level_items)) == extract_to.name:
-                extract_to = zip_path.parent  # Extract directly to parent folder. Target path to return will stay the same.
+                # Extract directly to parent folder. Target path to return will stay the same.
+                extract_to = zip_path.parent
 
             shutil.unpack_archive(zip_path, extract_to)
             LOGGER.info(f"Extracted files to {target_path.resolve()}.")


### PR DESCRIPTION
On windows the following bug happened when executing the operretina_demo notebook:
```
2025-08-08 12:01:42,573 - INFO - Extracted single file to ...\openretina_cache\euler_lab\hoefling_2024\stimuli\rgc_natstim_72x64_joint_normalized_2024-10-11.pkl.
---------------------------------------------------------------------------
PermissionError                           Traceback (most recent call last)
Cell In[13], line 1
----> 1 movie_stimulus_path = get_local_file_path(
      2     "https://huggingface.co/datasets/open-retina/open-retina/blob/main/euler_lab/hoefling_2024/stimuli/rgc_natstim_72x64_joint_normalized_2024-10-11.zip"
      3 )

File ~\open-retina\openretina\utils\file_utils.py:270, in get_local_file_path(file_path, cache_folder)
    268 elif file_path.startswith(HUGGINGFACE_BASE_URL):
    269     target_relative_path = file_path.split("main/")[-1]
--> 270     return huggingface_download(target_relative_path, Path(cache_folder))
    272 elif file_path.startswith("https://"):
    273     raise NotImplementedError(f"Only {GIN_BASE_URL} data storage is supported for now.")

File ~\open-retina\openretina\utils\file_utils.py:242, in huggingface_download(target_name, local_dir, unzip)
    239 files = api.list_repo_files(HUGGINGFACE_REPO_ID, repo_type="dataset")
    241 if target_name in files:  # Direct match, download the file
--> 242     downloaded_file = download_file_from_huggingface(target_name, local_dir, unzip)
    243     return Path(downloaded_file)
    244 else:  # Otherwise, assume it's a folder

File ~\open-retina\openretina\utils\file_utils.py:208, in download_file_from_huggingface(file_name, local_dir, unzip)
    200 downloaded_file = hf_hub_download(
    201     repo_id=HUGGINGFACE_REPO_ID,
    202     filename=file_name,
    203     local_dir=local_dir,
    204     repo_type="dataset",
    205 )
    207 if unzip and downloaded_file.endswith(".zip"):
--> 208     return unzip_and_cleanup(Path(downloaded_file))
    210 return downloaded_file

File ~\open-retina\openretina\utils\file_utils.py:43, in unzip_and_cleanup(zip_path)
     40     zf.extract(zip_contents[0], zip_path.parent)
     41     LOGGER.info(f"Extracted single file to {extracted_file.resolve()}.")
---> 43     zip_path.unlink()
     44     return extracted_file  # Return extracted file path
     46 # Check if zip contains a single folder with the same name as the zip

File ~\Anaconda3\envs\open_retina\Lib\pathlib.py:1342, in Path.unlink(self, missing_ok)
   1337 """
   1338 Remove this file or link.
   1339 If the path is a directory, use rmdir() instead.
   1340 """
   1341 try:
-> 1342     os.unlink(self)
   1343 except FileNotFoundError:
   1344     if not missing_ok:

PermissionError: [WinError 32] Impossibile accedere al file. Il file è utilizzato da un altro processo: '...\\openretina_cache\\euler_lab\\hoefling_2024\\stimuli\\rgc_natstim_72x64_joint_normalized_2024-10-11.zip'
```

AI says the following:
> after successfully extracting the single .pkl file (as logged), the code attempts to delete the temporary ZIP file using Path.unlink(), but fails because the ZIP file is still locked by the Python process on Windows. This is a common Windows-specific issue where file handles from libraries like zipfile remain open, preventing deletion until explicitly closed.

I think this is likely the cause, and in any case it's better to first close the file be moving out of the with block and only then unlinking the file. This should make sure that the file is properly closed before unlinking it.

For what it's worth, using Linux I tested that the download in the openretina_demo notebook still works even after deleting the openretina_cache folder.