### PR TITLE
Dev: allow loading of legacy models that use bias_param instead of bias_param in readout

### DIFF
--- a/openretina/models/core_readout.py
+++ b/openretina/models/core_readout.py
@@ -425,6 +425,7 @@ class ExampleCoreReadout(BaseCoreReadout):
         super().__init__(core=core, readout=readout, learning_rate=learning_rate, data_info=data_info)
 
     def on_load_checkpoint(self, checkpoint) -> None:
+    """ To support legacy models that use `bias_param` instead of `bias` in their readout layers.
         state_dict = checkpoint["state_dict"]
 
         readout_bias_keys = [k for k in state_dict.keys() if k.startswith("readout.") and k.endswith(".bias_param")]

--- a/openretina/models/core_readout.py
+++ b/openretina/models/core_readout.py
@@ -431,7 +431,8 @@ class ExampleCoreReadout(BaseCoreReadout):
         for key in readout_bias_keys:
             new_key = key.removesuffix(".bias_param") + ".bias"
             state_dict[new_key] = state_dict.pop(key)
-        LOGGER.warning(f"Renamed the following readout bias keys: {readout_bias_keys}")
+        if len(readout_bias_keys) > 0:
+            LOGGER.warning(f"Renamed the following readout bias keys: {readout_bias_keys}")
 
 
 def load_core_readout_from_remote(

--- a/openretina/models/core_readout.py
+++ b/openretina/models/core_readout.py
@@ -424,6 +424,15 @@ class ExampleCoreReadout(BaseCoreReadout):
 
         super().__init__(core=core, readout=readout, learning_rate=learning_rate, data_info=data_info)
 
+    def on_load_checkpoint(self, checkpoint) -> None:
+        state_dict = checkpoint["state_dict"]
+
+        readout_bias_keys = [k for k in state_dict.keys() if k.startswith("readout.") and k.endswith(".bias_param")]
+        for key in readout_bias_keys:
+            new_key = key.removesuffix(".bias_param") + ".bias"
+            state_dict[new_key] = state_dict.pop(key)
+        LOGGER.warning(f"Renamed the following readout bias keys: {readout_bias_keys}")
+
 
 def load_core_readout_from_remote(
     model_name: str,

--- a/openretina/models/core_readout.py
+++ b/openretina/models/core_readout.py
@@ -425,7 +425,7 @@ class ExampleCoreReadout(BaseCoreReadout):
         super().__init__(core=core, readout=readout, learning_rate=learning_rate, data_info=data_info)
 
     def on_load_checkpoint(self, checkpoint) -> None:
-    """ To support legacy models that use `bias_param` instead of `bias` in their readout layers.
+    """ To support legacy models that use `bias_param` instead of `bias` in their readout layers. """
         state_dict = checkpoint["state_dict"]
 
         readout_bias_keys = [k for k in state_dict.keys() if k.startswith("readout.") and k.endswith(".bias_param")]

--- a/openretina/models/core_readout.py
+++ b/openretina/models/core_readout.py
@@ -425,7 +425,7 @@ class ExampleCoreReadout(BaseCoreReadout):
         super().__init__(core=core, readout=readout, learning_rate=learning_rate, data_info=data_info)
 
     def on_load_checkpoint(self, checkpoint) -> None:
-    """ To support legacy models that use `bias_param` instead of `bias` in their readout layers. """
+        """To support legacy models that use `bias_param` instead of `bias` in their readout layers."""
         state_dict = checkpoint["state_dict"]
 
         readout_bias_keys = [k for k in state_dict.keys() if k.startswith("readout.") and k.endswith(".bias_param")]


### PR DESCRIPTION
To make the following work:
```
from openretina.models.core_readout import UnifiedCoreReadout, load_core_readout_model
load_core_readout_model("https://huggingface.co/datasets/open-retina/open-retina/blob/main/model_checkpoints/24-01-2025/hoefling_2024_base_low_res.ckpt", device="cpu")
```