### PR TITLE
Dev: hyperparameter tuning continues after errors

### DIFF
--- a/openretina/cli/openretina_main.py
+++ b/openretina/cli/openretina_main.py
@@ -54,7 +54,6 @@ class HydraRunner:
                 # If we are running hyperparameter tuning, we return the worst score on exceptions,
                 # otherwise we re-raise the exception
                 objective_direction: str = str(cfg.get("objective_direction")).lower()
-
                 if objective_direction == "maximize":
                     score = float("-inf")
                 elif objective_direction == "minimize":
@@ -63,6 +62,7 @@ class HydraRunner:
                     raise e
 
                 log.exception(f"Error during training, {objective_direction=}, {score=}")
+                return score
 
         _train()
 

--- a/openretina/cli/openretina_main.py
+++ b/openretina/cli/openretina_main.py
@@ -52,7 +52,7 @@ class HydraRunner:
             except Exception as e:
                 # If we are running hyperparameter tuning, we return the worst score on exceptions,
                 # otherwise we re-raise the exception
-                objective_direction: str = str(cfg.get("objective_direction")).lower()
+                objective_direction = str(cfg.get("objective_direction")).lower()
                 if objective_direction == "maximize":
                     score = float("-inf")
                 elif objective_direction == "minimize":

--- a/openretina/cli/openretina_main.py
+++ b/openretina/cli/openretina_main.py
@@ -53,19 +53,16 @@ class HydraRunner:
             except Exception as e:
                 # If we are running hyperparameter tuning, we return the worst score on exceptions,
                 # otherwise we re-raise the exception
-                try:
-                    direction: str | None = str(cfg.hydra.sweeper.direction).lower()
-                except Exception:
-                    direction = None
+                objective_direction: str = str(cfg.get("objective_direction")).lower()
 
-                if direction == "maximize":
-                    log.exception("Error during training, score=-inf")
-                    return float("-inf")
-                elif direction == "minimize":
-                    log.exception("Error during training, score=inf")
-                    return float("inf")
+                if objective_direction == "maximize":
+                    score = float("-inf")
+                elif objective_direction == "minimize":
+                    score = float("inf")
                 else:
                     raise e
+
+                log.exception(f"Error during training, {objective_direction=}, {score=}")
 
         _train()
 

--- a/openretina/cli/openretina_main.py
+++ b/openretina/cli/openretina_main.py
@@ -48,8 +48,7 @@ class HydraRunner:
                 cfg.paths.cache_dir = get_cache_directory()
 
             try:
-                score = train_model(cfg)
-                return score
+                return train_model(cfg)
             except Exception as e:
                 # If we are running hyperparameter tuning, we return the worst score on exceptions,
                 # otherwise we re-raise the exception

--- a/openretina/data_io/hoefling_2024/dataloaders.py
+++ b/openretina/data_io/hoefling_2024/dataloaders.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 import numpy as np
 import torch
@@ -210,7 +210,7 @@ def natmov_dataloaders_v2(
 
 def get_chirp_dataloaders(
     neuron_data_dictionary,
-    train_chunk_size: Optional[int] = None,
+    train_chunk_size: int | None = None,
     batch_size: int = 32,
 ):
     assert isinstance(neuron_data_dictionary, dict), (
@@ -280,7 +280,7 @@ def get_chirp_dataloaders(
 
 def get_mb_dataloaders(
     neuron_data_dictionary,
-    train_chunk_size: Optional[int] = None,
+    train_chunk_size: int | None = None,
     batch_size: int = 32,
 ):
     assert isinstance(neuron_data_dictionary, dict), (

--- a/openretina/insilico/vector_field_analysis/vector_field_analysis.py
+++ b/openretina/insilico/vector_field_analysis/vector_field_analysis.py
@@ -5,7 +5,6 @@ from typing import Any
 import matplotlib.pyplot as plt
 import numpy as np
 import torch
-from git import Optional
 from PIL import Image
 from scipy.interpolate import griddata
 from sklearn.decomposition import PCA
@@ -148,8 +147,8 @@ def prepare_movies_dataset(
     session_id: str,
     n_image_frames: int = 16,
     normalize_movies: bool = True,
-    image_library: Optional[np.ndarray] = None,
-    image_dir: Optional[str] = None,
+    image_library: np.ndarray | None = None,
+    image_dir: str | None = None,
     device: str = "cuda",
 ) -> tuple[np.ndarray, int]:
     """
@@ -483,7 +482,7 @@ def plot_clean_vectorfield(
     explained_variance: np.ndarray,
     x_bins: int = 31,
     y_bins: int = 31,
-    responses: Optional[np.ndarray] = None,
+    responses: np.ndarray | None = None,
 ) -> plt.Figure:
     """
     Plots a cleaned vector field representation of binned image and LSTA data projected onto principal components.


### PR DESCRIPTION
This requires to define objective_direction in the config and set it to `maximize` or `minimize`.
It will still log the full exception then and assign the run +-float('inf') as a score, and continue with the remaining hyperparameters.

Spurious: removed `from git import Optional`