### PR TITLE
Fix lag computation for Sridhar 

### DIFF
--- a/openretina/cli/eval.py
+++ b/openretina/cli/eval.py
@@ -39,9 +39,9 @@ def evaluate_model(cfg: DictConfig) -> float:
     log.info("Logging full config:")
     log.info(OmegaConf.to_yaml(cfg))
 
-    if cfg.paths.cache_dir is None:
-        raise ValueError("Please provide a cache_dir for the data in the config file or as a command line argument.")
-    if cfg.evaluation.model_path is None:
+    if cfg.get("paths").get("cache_dir") is None:
+        raise ValueError("Please provide paths.cache_dir for the data in the config file or via the command line.")
+    if cfg.get("evaluation", {}).get("model_path") is None:
         raise ValueError("Please provide evaluation.model_path to define which model to test.")
 
     # Set cache folder

--- a/openretina/cli/eval.py
+++ b/openretina/cli/eval.py
@@ -89,12 +89,13 @@ def evaluate_model(cfg: DictConfig) -> float:
         dataset = dl.dataset
 
         with torch.no_grad():
-            model_responses_torch_array: list[torch.Tensor] = []
+            model_responses_torch_array = []
             targets_array = []
             for data_point in dl:
                 model_resp_batch = model.forward(data_point[0].to(device), data_key=session)
-                model_responses_torch_array.extend(model_resp_batch.detach())
-                targets_array.extend(data_point[1])
+                model_resp = model_resp_batch.flatten(0, 1)
+                model_responses_torch_array.append(model_resp)
+                targets_array.append(data_point[1].flatten(0, 1))
             model_responses_torch = torch.concat(model_responses_torch_array)
             targets = torch.concat(targets_array).to(device)
             poisson_loss_session = poisson_loss(model_responses_torch.unsqueeze(0), targets.unsqueeze(0))

--- a/openretina/cli/eval.py
+++ b/openretina/cli/eval.py
@@ -103,7 +103,6 @@ def evaluate_model(cfg: DictConfig) -> float:
         model_responses = model_responses_torch.cpu().numpy()
 
         avg_responses = dataset.responses.numpy()
-        has_trial_data = True
         try:
             responses_by_trial = dataset.test_responses_by_trial.cpu().numpy()
             responses_by_trial = reorder_like_a(a=avg_responses, b=responses_by_trial)
@@ -123,7 +122,6 @@ def evaluate_model(cfg: DictConfig) -> float:
                 exc_info=True,
             )
             responses_by_trial = avg_responses[:, np.newaxis, :]
-            has_trial_data = False
 
         avg_responses, responses_by_trial, lag = align_responses_to_model_output(
             targets=targets,
@@ -146,20 +144,21 @@ def evaluate_model(cfg: DictConfig) -> float:
         # Compute evaluation metrics (all are arrays of length n_neurons_session)
         corr_to_average = correlation_numpy(avg_responses, model_responses, axis=0)
         mse_to_average = MSE_numpy(avg_responses, model_responses, axis=0)
-        feve_values = feve(responses_by_trial, model_responses)
-        # we already cut the frames from responses_by_trial
-        jackknife, _ = oracle_corr_jackknife(responses_by_trial, cut_first_n_frames=None)
 
-        # Compute variance ratio (explainable to total variance ratio)
-        n_trials_for_var = responses_by_trial.shape[1]
-        if has_trial_data and n_trials_for_var > 1:
+        n_trials = responses_by_trial.shape[1]
+        if n_trials > 1:
+            feve_values = feve(responses_by_trial, model_responses)
+            # we already cut the frames from responses_by_trial
+            jackknife, _ = oracle_corr_jackknife(responses_by_trial, cut_first_n_frames=None)
             var_ratio, explainable_var = explainable_vs_total_var(responses_by_trial)
         else:
+            feve_values = np.full(n_neurons_session, np.nan)
+            jackknife = np.full(n_neurons_session, np.nan)
             # Cannot compute var_ratio without multiple trials
             var_ratio = np.full(n_neurons_session, np.nan)
 
+
         # Compute per-trial metrics
-        n_trials = responses_by_trial.shape[1]
         n_trials_per_session.append(n_trials)
         corr_by_trial = {}
         mse_by_trial = {}

--- a/openretina/cli/eval.py
+++ b/openretina/cli/eval.py
@@ -39,7 +39,7 @@ def evaluate_model(cfg: DictConfig) -> float:
     log.info("Logging full config:")
     log.info(OmegaConf.to_yaml(cfg))
 
-    if cfg.get("paths").get("cache_dir") is None:
+    if cfg.get("paths", {}).get("cache_dir") is None:
         raise ValueError("Please provide paths.cache_dir for the data in the config file or via the command line.")
     if cfg.get("evaluation", {}).get("model_path") is None:
         raise ValueError("Please provide evaluation.model_path to define which model to test.")

--- a/openretina/cli/eval.py
+++ b/openretina/cli/eval.py
@@ -93,10 +93,8 @@ def evaluate_model(cfg: DictConfig) -> float:
             targets_array = []
             for data_point in dl:
                 model_resp_batch = model.forward(data_point[0].to(device), data_key=session)
-                # flatten batch dim
-                model_resp = model_resp_batch.flatten(0, 1)
-                model_responses_torch_array.append(model_resp)
-                targets_array.append(data_point[1].flatten(0, 1))
+                model_responses_torch_array.extend(model_resp_batch.detach())
+                targets_array.extend(data_point[1])
             model_responses_torch = torch.concat(model_responses_torch_array)
             targets = torch.concat(targets_array).to(device)
             poisson_loss_session = poisson_loss(model_responses_torch.unsqueeze(0), targets.unsqueeze(0))

--- a/openretina/cli/eval.py
+++ b/openretina/cli/eval.py
@@ -17,7 +17,7 @@ from openretina.eval.metrics import MSE_numpy, correlation_numpy, explainable_vs
 from openretina.eval.oracles import oracle_corr_jackknife
 from openretina.models.core_readout import load_core_readout_model
 from openretina.modules.losses import PoissonLoss3d
-from openretina.utils.eval_utils import EvaluationSummary
+from openretina.utils.eval_utils import EvaluationSummary, align_responses_to_model_output
 from openretina.utils.frame_fingerprints import compute_dataloader_statistics
 from openretina.utils.misc import reorder_like_a
 
@@ -127,20 +127,16 @@ def evaluate_model(cfg: DictConfig) -> float:
             responses_by_trial = avg_responses[:, np.newaxis, :]
             has_trial_data = False
 
-        # adjust responses to lag
-        new_lag = avg_responses.shape[0] - model_responses.shape[0]
-        if lag < 0:
-            lag = new_lag
-        elif new_lag != lag:
-            log.error(
-                f"Inconsistent lag between sessions: {new_lag=} {lag=}"
-                "\nThis might indicate a problem with the model or the data."
-            )
-            lag = new_lag
+        avg_responses, responses_by_trial, lag = align_responses_to_model_output(
+            targets=targets,
+            model_responses=model_responses,
+            avg_responses=avg_responses,
+            responses_by_trial=responses_by_trial,
+            dataset=dataset,
+            lag=lag,
+        )
 
-        avg_responses = avg_responses[lag:]
         n_neurons_session = avg_responses.shape[1]
-        responses_by_trial = responses_by_trial[lag:]
 
         if model_responses.shape != avg_responses.shape:
             raise ValueError(f"Inconsistent Shapes: {model_responses.shape=}, {avg_responses.shape}, {lag=}")

--- a/openretina/cli/eval.py
+++ b/openretina/cli/eval.py
@@ -89,7 +89,7 @@ def evaluate_model(cfg: DictConfig) -> float:
         dataset = dl.dataset
 
         with torch.no_grad():
-            model_responses_torch_array = []
+            model_responses_torch_array: list[torch.Tensor] = []
             targets_array = []
             for data_point in dl:
                 model_resp_batch = model.forward(data_point[0].to(device), data_key=session)
@@ -147,7 +147,8 @@ def evaluate_model(cfg: DictConfig) -> float:
         corr_to_average = correlation_numpy(avg_responses, model_responses, axis=0)
         mse_to_average = MSE_numpy(avg_responses, model_responses, axis=0)
         feve_values = feve(responses_by_trial, model_responses)
-        jackknife, _ = oracle_corr_jackknife(responses_by_trial, cut_first_n_frames=lag)
+        # we already cut the frames from responses_by_trial
+        jackknife, _ = oracle_corr_jackknife(responses_by_trial, cut_first_n_frames=None)
 
         # Compute variance ratio (explainable to total variance ratio)
         n_trials_for_var = responses_by_trial.shape[1]

--- a/openretina/cli/eval.py
+++ b/openretina/cli/eval.py
@@ -157,7 +157,6 @@ def evaluate_model(cfg: DictConfig) -> float:
             # Cannot compute var_ratio without multiple trials
             var_ratio = np.full(n_neurons_session, np.nan)
 
-
         # Compute per-trial metrics
         n_trials_per_session.append(n_trials)
         corr_by_trial = {}

--- a/openretina/data_io/sridhar_2025/dataloaders.py
+++ b/openretina/data_io/sridhar_2025/dataloaders.py
@@ -182,9 +182,6 @@ class MarmosetMovieDataset(Dataset):
 
         self.frame_overhead = (num_of_frames - 1) * self.temporal_dilation + hidden_reach
 
-        if time_chunk_size is not None:
-            self.time_chunk_size = time_chunk_size + self.frame_overhead
-
         self.subsample = subsample
         self.device = device
         self.basepath = Path(dir).absolute()
@@ -208,10 +205,17 @@ class MarmosetMovieDataset(Dataset):
         self.random_indices = np.random.permutation(indices)
         self.n_neurons = self.train_responses.shape[0]
         self.num_of_trials = self.train_responses.shape[2]
-        self.num_of_imgs = int(self.train_responses.shape[1])
 
         if test:
             self.num_of_imgs = self.test_responses.shape[1]
+        else:
+            self.num_of_imgs = self.train_responses.shape[1]
+
+        if time_chunk_size is None:
+            self.time_chunk_size = self.num_of_imgs
+        else:
+            self.time_chunk_size = time_chunk_size
+        self.time_chunk_size += self.frame_overhead
 
         self.cache: list[Any] = []
         self.last_start_index = -1
@@ -695,102 +699,45 @@ def frame_movie_loader(
             )
         if isinstance(num_of_frames, int):
             num_of_frames = [num_of_frames]
-        train_loader = get_dataloader(
-            {
-                "train_responses": train_responses,
-                "test_responses": test_responses,
-                "test_responses_by_trial": responses[retina_index].get("test_responses_by_trial"),
-            },
-            fixations=fixations,
-            path=basepath,
-            indices=train_ids,
-            test=False,
-            batch_size=batch_size,
-            num_of_frames=num_of_frames[0],
-            device=device,
-            crop=crop,
-            shuffle=True if shuffle is None else shuffle,
-            subsample=subsample,
-            time_chunk_size=time_chunk_size,
-            num_of_layers=num_of_layers,
-            frames=frames,
-            num_of_hidden_frames=num_of_frames[1:] if len(num_of_frames) > 1 else None,
-            padding=padding,
-            full_img_h=full_img_h,
-            full_img_w=full_img_w,
-            img_h=img_h,
-            img_w=img_w,
-            temporal_dilation=temporal_dilation,
-            hidden_temporal_dilation=hidden_temporal_dilation,
-            excluded_cells=excluded_cells,
-            locations=locations,
-        )
 
-        valid_loader = get_dataloader(
-            {
-                "train_responses": train_responses,
-                "test_responses": test_responses,
-                "test_responses_by_trial": responses[retina_index].get("test_responses_by_trial"),
-            },
-            path=basepath,
-            indices=valid_ids,
-            test=False,
-            batch_size=batch_size,
-            fixations=fixations,
-            num_of_frames=num_of_frames[0],
-            device=device,
-            crop=crop,
-            shuffle=False if shuffle is None else shuffle,
-            subsample=subsample,
-            time_chunk_size=time_chunk_size,
-            num_of_layers=num_of_layers,
-            frames=frames,
-            num_of_hidden_frames=num_of_frames[1:] if len(num_of_frames) > 1 else None,
-            padding=padding,
-            full_img_h=full_img_h,
-            full_img_w=full_img_w,
-            img_h=img_h,
-            img_w=img_w,
-            temporal_dilation=temporal_dilation,
-            hidden_temporal_dilation=hidden_temporal_dilation,
-            excluded_cells=excluded_cells,
-            locations=locations,
-        )
+        responses_dict = {
+            "train_responses": train_responses,
+            "test_responses": test_responses,
+            "test_responses_by_trial": responses[retina_index].get("test_responses_by_trial"),
+        }
 
-        test_loader = get_dataloader(
-            {
-                "train_responses": train_responses,
-                "test_responses": test_responses,
-                "test_responses_by_trial": responses[retina_index].get("test_responses_by_trial"),
-            },
-            fixations=fixations,
-            path=basepath,
-            indices=train_ids,
-            test=True,
-            batch_size=batch_size,
-            num_of_frames=num_of_frames[0],
-            device=device,
-            crop=crop,
-            shuffle=False,
-            subsample=subsample,
-            time_chunk_size=time_chunk_size,
-            num_of_layers=num_of_layers,
-            frames=frames,
-            num_of_hidden_frames=num_of_frames[1:] if len(num_of_frames) > 1 else None,
-            padding=padding,
-            full_img_h=full_img_h,
-            full_img_w=full_img_w,
-            img_h=img_h,
-            img_w=img_w,
-            temporal_dilation=temporal_dilation,
-            hidden_temporal_dilation=hidden_temporal_dilation,
-            excluded_cells=excluded_cells,
-            locations=locations,
-        )
-
-        dataloaders["train"][retina_index] = train_loader
-        dataloaders["validation"][retina_index] = valid_loader
-        dataloaders["test"][retina_index] = test_loader
+        for split, indices, is_test, time_chunk_size_value, shuffle in [
+            ("train", train_ids, False, time_chunk_size, True if shuffle is None else shuffle),
+            ("validation", valid_ids, False, time_chunk_size, False if shuffle is None else shuffle),
+            ("test", train_ids, True, None, False),
+        ]:
+            loader = get_dataloader(
+                responses_dict,
+                fixations=fixations,
+                path=basepath,
+                indices=indices,
+                test=is_test,
+                batch_size=batch_size,
+                num_of_frames=num_of_frames[0],
+                device=device,
+                crop=crop,
+                shuffle=shuffle,
+                subsample=subsample,
+                time_chunk_size=time_chunk_size_value,
+                num_of_layers=num_of_layers,
+                frames=frames,
+                num_of_hidden_frames=num_of_frames[1:] if len(num_of_frames) > 1 else None,
+                padding=padding,
+                full_img_h=full_img_h,
+                full_img_w=full_img_w,
+                img_h=img_h,
+                img_w=img_w,
+                temporal_dilation=temporal_dilation,
+                hidden_temporal_dilation=hidden_temporal_dilation,
+                excluded_cells=excluded_cells,
+                locations=locations,
+            )
+            dataloaders[split][retina_index] = loader
 
     return dataloaders
 
@@ -811,7 +758,7 @@ class NoiseDataset(Dataset):
         num_of_frames: int = 15,
         num_of_layers: int = 1,
         device: str = "cpu",
-        time_chunk_size: int = 1,
+        time_chunk_size: int | None = 1,
         temporal_dilation: int = 1,
         hidden_temporal_dilation: int | str | tuple = 1,
         num_of_hidden_frames: int | tuple | None = 15,
@@ -894,7 +841,6 @@ class NoiseDataset(Dataset):
 
         self.frame_overhead = (self.num_of_frames - 1) * self.temporal_dilation + hidden_reach
 
-        self.time_chunk_size = time_chunk_size + self.frame_overhead
         self.subsample = subsample
         self.device = device
         self.trial_prefix = trial_prefix
@@ -914,13 +860,20 @@ class NoiseDataset(Dataset):
         self.random_indices = np.random.permutation(indices)
         self.n_neurons = self.train_responses.shape[0]
         self.num_of_trials = self.train_responses.shape[2]
-        self.num_of_imgs = int(self.train_responses.shape[1])
         self.locations = locations
         self.excluded_cells = excluded_cells
 
         # Checks if trials are saved in evenly sized files
         if test:
             self.num_of_imgs = self.test_responses.shape[1]
+        else:
+            self.num_of_imgs = self.train_responses.shape[1]
+        if time_chunk_size is None:
+            self.time_chunk_size = self.num_of_imgs
+        else:
+            self.time_chunk_size = time_chunk_size
+        self.time_chunk_size += self.frame_overhead
+
         self._test = test
         if self._test:
             self._len = (
@@ -1222,92 +1175,47 @@ def white_noise_loader(
             )
         if isinstance(num_of_frames, int):
             num_of_frames = [num_of_frames]
-        train_loader = get_noise_dataloader(
-            {
-                "train_responses": train_responses,
-                "test_responses": test_responses,
-                "test_responses_by_trial": responses[retina_index].get("test_responses_by_trial"),
-            },
-            path=dataset_train_image_path,
-            indices=train_ids,
-            test=False,
-            shuffle=False,
-            batch_size=batch_size,
-            use_cache=use_cache,
-            cache_maxsize=cache_maxsize,
-            num_of_frames=num_of_frames[0],
-            num_of_hidden_frames=num_of_frames[1:] if len(num_of_frames) > 1 else None,
-            device=device,
-            crop=crop,
-            subsample=subsample,
-            time_chunk_size=time_chunk_size,
-            num_of_layers=num_of_layers,
-            temporal_dilation=temporal_dilation,
-            hidden_temporal_dilation=hidden_temporal_dilation,
-            extra_frame=extra_frame,
-            chunked_sampling=chunked_sampling,
-            locations=locations,
-            excluded_cells=excluded_cells,
-        )
-
-        valid_loader = get_noise_dataloader(
-            {
-                "train_responses": train_responses,
-                "test_responses": test_responses,
-                "test_responses_by_trial": responses[retina_index].get("test_responses_by_trial"),
-            },
-            path=dataset_train_image_path,
-            indices=valid_ids,
-            test=False,
-            batch_size=batch_size,
-            use_cache=use_cache,
-            cache_maxsize=cache_maxsize,
-            shuffle=False,
-            num_of_frames=num_of_frames[0],
-            num_of_hidden_frames=num_of_frames[1:] if len(num_of_frames) > 1 else None,
-            device=device,
-            crop=crop,
-            subsample=subsample,
-            time_chunk_size=time_chunk_size,
-            num_of_layers=num_of_layers,
-            temporal_dilation=temporal_dilation,
-            hidden_temporal_dilation=hidden_temporal_dilation,
-            extra_frame=extra_frame,
-            chunked_sampling=chunked_sampling,
-            locations=locations,
-            excluded_cells=excluded_cells,
-        )
-
-        test_loader = get_noise_dataloader(
-            {
-                "train_responses": train_responses,
-                "test_responses": test_responses,
-                "test_responses_by_trial": responses[retina_index].get("test_responses_by_trial"),
-            },
-            path=dataset_test_image_path,
-            indices=train_ids,
-            test=True,
-            batch_size=batch_size,
-            use_cache=use_cache,
-            shuffle=False,
-            cache_maxsize=20,
-            num_of_frames=num_of_frames[0],
-            num_of_hidden_frames=num_of_frames[1:] if len(num_of_frames) > 1 else None,
-            device=device,
-            crop=crop,
-            subsample=subsample,
-            time_chunk_size=time_chunk_size,
-            num_of_layers=num_of_layers,
-            temporal_dilation=temporal_dilation,
-            hidden_temporal_dilation=hidden_temporal_dilation,
-            extra_frame=extra_frame,
-            chunked_sampling=False,
-            locations=locations,
-            excluded_cells=excluded_cells,
-        )
-
-        dataloaders["train"][retina_index] = train_loader
-        dataloaders["validation"][retina_index] = valid_loader
-        dataloaders["test"][retina_index] = test_loader
+        responses_dict = {
+            "train_responses": train_responses,
+            "test_responses": test_responses,
+            "test_responses_by_trial": responses[retina_index].get("test_responses_by_trial"),
+        }
+        for split, indices, is_test, cache_size, chunked_sampling_value, time_chunk_size_value, image_path in [
+            ("train", train_ids, False, cache_maxsize, chunked_sampling, time_chunk_size, dataset_train_image_path),
+            (
+                "validation",
+                valid_ids,
+                False,
+                cache_maxsize,
+                chunked_sampling,
+                time_chunk_size,
+                dataset_train_image_path,
+            ),
+            ("test", train_ids, True, 20, False, time_chunk_size, dataset_test_image_path),
+        ]:
+            loader = get_noise_dataloader(
+                responses_dict,
+                path=image_path,
+                indices=indices,
+                test=is_test,
+                shuffle=False,
+                batch_size=batch_size,
+                use_cache=use_cache,
+                cache_maxsize=cache_size,
+                num_of_frames=num_of_frames[0],
+                num_of_hidden_frames=num_of_frames[1:] if len(num_of_frames) > 1 else None,
+                device=device,
+                crop=crop,
+                subsample=subsample,
+                time_chunk_size=time_chunk_size_value,
+                num_of_layers=num_of_layers,
+                temporal_dilation=temporal_dilation,
+                hidden_temporal_dilation=hidden_temporal_dilation,
+                extra_frame=extra_frame,
+                chunked_sampling=chunked_sampling_value,
+                locations=locations,
+                excluded_cells=excluded_cells,
+            )
+            dataloaders[split][retina_index] = loader
 
     return dataloaders

--- a/openretina/data_io/sridhar_2025/dataloaders.py
+++ b/openretina/data_io/sridhar_2025/dataloaders.py
@@ -131,7 +131,7 @@ class MarmosetMovieDataset(Dataset):
         num_of_hidden_frames: int | tuple = 15,
         num_of_layers: int = 1,
         device: str = "cpu",
-        time_chunk_size: int | None = None,
+        time_chunk_size: int = 1,
         full_img_w: int = 1000,
         full_img_h: int = 800,
         img_w: int = 800,
@@ -210,12 +210,7 @@ class MarmosetMovieDataset(Dataset):
             self.num_of_imgs = self.test_responses.shape[1]
         else:
             self.num_of_imgs = self.train_responses.shape[1]
-
-        if time_chunk_size is None:
-            self.time_chunk_size = self.num_of_imgs
-        else:
-            self.time_chunk_size = time_chunk_size
-        self.time_chunk_size += self.frame_overhead
+        self.time_chunk_size = time_chunk_size + self.frame_overhead
 
         self.cache: list[Any] = []
         self.last_start_index = -1
@@ -480,7 +475,7 @@ def frame_movie_loader(
     cell_index=None,
     retina_index=None,
     device: str = "cpu",
-    time_chunk_size=None,
+    time_chunk_size: int = 1,
     num_of_layers=None,
     excluded_cells: dict[Any, list[int]] | None = None,
     frame_file="_img_",
@@ -706,10 +701,10 @@ def frame_movie_loader(
             "test_responses_by_trial": responses[retina_index].get("test_responses_by_trial"),
         }
 
-        for split, indices, is_test, time_chunk_size_value, shuffle in [
-            ("train", train_ids, False, time_chunk_size, True if shuffle is None else shuffle),
-            ("validation", valid_ids, False, time_chunk_size, False if shuffle is None else shuffle),
-            ("test", train_ids, True, None, False),
+        for split, indices, is_test, shuffle in [
+            ("train", train_ids, False, True if shuffle is None else shuffle),
+            ("validation", valid_ids, False, False if shuffle is None else shuffle),
+            ("test", train_ids, True, False),
         ]:
             loader = get_dataloader(
                 responses_dict,
@@ -723,7 +718,7 @@ def frame_movie_loader(
                 crop=crop,
                 shuffle=shuffle,
                 subsample=subsample,
-                time_chunk_size=time_chunk_size_value,
+                time_chunk_size=time_chunk_size,
                 num_of_layers=num_of_layers,
                 frames=frames,
                 num_of_hidden_frames=num_of_frames[1:] if len(num_of_frames) > 1 else None,
@@ -758,7 +753,7 @@ class NoiseDataset(Dataset):
         num_of_frames: int = 15,
         num_of_layers: int = 1,
         device: str = "cpu",
-        time_chunk_size: int | None = 1,
+        time_chunk_size: int = 1,
         temporal_dilation: int = 1,
         hidden_temporal_dilation: int | str | tuple = 1,
         num_of_hidden_frames: int | tuple | None = 15,
@@ -868,11 +863,7 @@ class NoiseDataset(Dataset):
             self.num_of_imgs = self.test_responses.shape[1]
         else:
             self.num_of_imgs = self.train_responses.shape[1]
-        if time_chunk_size is None:
-            self.time_chunk_size = self.num_of_imgs
-        else:
-            self.time_chunk_size = time_chunk_size
-        self.time_chunk_size += self.frame_overhead
+        self.time_chunk_size = time_chunk_size + self.frame_overhead
 
         self._test = test
         if self._test:
@@ -1180,18 +1171,17 @@ def white_noise_loader(
             "test_responses": test_responses,
             "test_responses_by_trial": responses[retina_index].get("test_responses_by_trial"),
         }
-        for split, indices, is_test, cache_size, chunked_sampling_value, time_chunk_size_value, image_path in [
-            ("train", train_ids, False, cache_maxsize, chunked_sampling, time_chunk_size, dataset_train_image_path),
+        for split, indices, is_test, cache_size, chunked_sampling_value, image_path in [
+            ("train", train_ids, False, cache_maxsize, chunked_sampling, dataset_train_image_path),
             (
                 "validation",
                 valid_ids,
                 False,
                 cache_maxsize,
                 chunked_sampling,
-                time_chunk_size,
                 dataset_train_image_path,
             ),
-            ("test", train_ids, True, 20, False, time_chunk_size, dataset_test_image_path),
+            ("test", train_ids, True, 20, False, dataset_test_image_path),
         ]:
             loader = get_noise_dataloader(
                 responses_dict,
@@ -1207,7 +1197,7 @@ def white_noise_loader(
                 device=device,
                 crop=crop,
                 subsample=subsample,
-                time_chunk_size=time_chunk_size_value,
+                time_chunk_size=time_chunk_size,
                 num_of_layers=num_of_layers,
                 temporal_dilation=temporal_dilation,
                 hidden_temporal_dilation=hidden_temporal_dilation,

--- a/openretina/models/core_readout.py
+++ b/openretina/models/core_readout.py
@@ -111,7 +111,7 @@ class BaseCoreReadout(LightningModule):
         regularization_loss_core = self.core.regularizer()
         regularization_loss_readout = self.readout.regularizer(session_id)  # type: ignore
         total_loss = loss + regularization_loss_core + regularization_loss_readout
-        evaluation_loss = -self.evaluation_loss.forward(model_output, data_point.targets)
+        evaluation_loss = self.evaluation_loss.forward(model_output, data_point.targets)
 
         self.log("regularization_loss_core", regularization_loss_core, on_step=False, on_epoch=True)
         self.log("regularization_loss_readout", regularization_loss_readout, on_step=False, on_epoch=True)

--- a/openretina/utils/eval_utils.py
+++ b/openretina/utils/eval_utils.py
@@ -261,10 +261,10 @@ class EvaluationSummary:
 
 
 def align_responses_to_model_output(
-    targets: torch.Tensor,
-    model_responses: np.ndarray,
-    avg_responses: np.ndarray,
-    responses_by_trial: np.ndarray,
+    targets: torch.Tensor | np.ndarray,
+    model_responses: torch.Tensor | np.ndarray,
+    avg_responses: torch.Tensor | np.ndarray,
+    responses_by_trial: torch.Tensor | np.ndarray,
     dataset: torch.utils.data.Dataset,
     lag: int = -1,
 ) -> tuple[np.ndarray, np.ndarray, int]:
@@ -293,7 +293,7 @@ def align_responses_to_model_output(
     model_len = model_responses.shape[0]
     full_len = avg_responses.shape[0]
 
-    if dataloader_target_len == model_len and full_len >= model_len:
+    if dataloader_target_len == model_len and full_len > model_len:
         # Dataloader pre-trims frame_overhead per chunk; use it for correct alignment
         if not hasattr(dataset, "frame_overhead") and not hasattr(dataset, "lag"):
             raise ValueError(
@@ -308,16 +308,17 @@ def align_responses_to_model_output(
     else:
         # Standard case: model output is shorter than full responses by lag in dataloader targets
         new_lag = dataloader_target_len - model_len
+        if new_lag < 0:
+            raise ValueError(f"Negative lag: {new_lag=} ({dataloader_target_len=} {model_len=}")
         avg_responses = avg_responses[new_lag : new_lag + model_len]
         responses_by_trial = responses_by_trial[new_lag : new_lag + model_len]
 
     if lag < 0:
         lag = new_lag
     elif new_lag != lag:
-        log.error(
+        raise ValueError(
             f"Inconsistent lag between sessions: {new_lag=} {lag=}"
             "\nThis might indicate a problem with the model or the data."
         )
-        lag = new_lag
 
     return avg_responses, responses_by_trial, lag

--- a/openretina/utils/eval_utils.py
+++ b/openretina/utils/eval_utils.py
@@ -301,11 +301,8 @@ def align_responses_to_model_output(
                 "Dataset does not have `frame_overhead` or `lag`, which is required for correct alignment when the "
                 "dataloader pre-trims responses."
             )
-        start_trim = (
-            getattr(dataset, "frame_overhead", 0)
-            + getattr(dataset, "lag", 0)
-            + getattr(dataset, "extra_frame", 0)
-        )
+        start_trim = getattr(dataset, "frame_overhead", 0) + getattr(dataset, "lag", 0)
+        start_trim += getattr(dataset, "extra_frame", 0)
         new_lag = start_trim
         end_trim = start_trim + model_len
         if end_trim > full_len:

--- a/openretina/utils/eval_utils.py
+++ b/openretina/utils/eval_utils.py
@@ -1,14 +1,18 @@
 """Utilities for model evaluation and result aggregation."""
 
 import json
+import logging
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
 
 import numpy as np
 import pandas as pd
+import torch
 
 from openretina.data_io.base import DatasetStatistics
+
+log = logging.getLogger(__name__)
 
 
 @dataclass
@@ -254,3 +258,66 @@ class EvaluationSummary:
             print(f"  {'MSE':30s}: {self.mse_by_trial_mean:.4f} (+/-{self.mse_by_trial_std:.4f})")
 
         print("=" * 80)
+
+
+def align_responses_to_model_output(
+    targets: torch.Tensor,
+    model_responses: np.ndarray,
+    avg_responses: np.ndarray,
+    responses_by_trial: np.ndarray,
+    dataset: torch.utils.data.Dataset,
+    lag: int = -1,
+) -> tuple[np.ndarray, np.ndarray, int]:
+    """Align responses to model output.
+
+    When the dataloader pre-trims responses (e.g. Sridhar chunked dataset), targets in batches already
+    match model output length. In that case, use `frame_overhead` or `lag` Dataset attributes to trim.
+    In that case, we also trim the end of the responses to match the model output length, which can occur as a result
+    of dataloaders chunking behaviour and potential dropping of last incomplete chunks.
+
+    Args:
+        targets: Target responses collated from the dataloader.
+        model_responses: Model responses to the targets collated from the dataloader.
+        avg_responses: Average responses, from the underlying dataset.
+        responses_by_trial: Responses by trial, from the underlying dataset.
+        dataset: Dataset object.
+        lag: Temporal lag of the model output with respect to the targets from known parameters or a previous session.
+            Leave to -1 if unknown or computing this on the first session (or a single session evaluation).
+
+    Returns:
+        avg_responses: Aligned average responses.
+        responses_by_trial: Aligned responses by trial.
+        lag: Re-computed temporal lag of the model output with respect to the targets for this session's responses.
+    """
+    dataloader_target_len = targets.shape[0]
+    model_len = model_responses.shape[0]
+    full_len = avg_responses.shape[0]
+
+    if dataloader_target_len == model_len and full_len >= model_len:
+        # Dataloader pre-trims frame_overhead per chunk; use it for correct alignment
+        if not hasattr(dataset, "frame_overhead") and not hasattr(dataset, "lag"):
+            raise ValueError(
+                "Dataset does not have `frame_overhead` or `lag`, which is required for correct alignment when the "
+                "dataloader pre-trims responses."
+            )
+        start_trim = getattr(dataset, "frame_overhead", 0) + getattr(dataset, "lag", 0)
+        new_lag = start_trim
+        avg_responses = avg_responses[start_trim : start_trim + model_len]
+        responses_by_trial = responses_by_trial[start_trim : start_trim + model_len]
+
+    else:
+        # Standard case: model output is shorter than full responses by lag in dataloader targets
+        new_lag = dataloader_target_len - model_len
+        avg_responses = avg_responses[new_lag : new_lag + model_len]
+        responses_by_trial = responses_by_trial[new_lag : new_lag + model_len]
+
+    if lag < 0:
+        lag = new_lag
+    elif new_lag != lag:
+        log.error(
+            f"Inconsistent lag between sessions: {new_lag=} {lag=}"
+            "\nThis might indicate a problem with the model or the data."
+        )
+        lag = new_lag
+
+    return avg_responses, responses_by_trial, lag

--- a/openretina/utils/eval_utils.py
+++ b/openretina/utils/eval_utils.py
@@ -271,7 +271,8 @@ def align_responses_to_model_output(
     """Align responses to model output.
 
     When the dataloader pre-trims responses (e.g. Sridhar chunked dataset), targets in batches already
-    match model output length. In that case, use `frame_overhead` or `lag` Dataset attributes to trim.
+    match model output length. In that case, use `frame_overhead`, `lag`, and any dataset-specific
+    response offset such as `extra_frame` to trim.
     In that case, we also trim the end of the responses to match the model output length, which can occur as a result
     of dataloaders chunking behaviour and potential dropping of last incomplete chunks.
 
@@ -294,16 +295,25 @@ def align_responses_to_model_output(
     full_len = avg_responses.shape[0]
 
     if dataloader_target_len == model_len and full_len > model_len:
-        # Dataloader pre-trims frame_overhead per chunk; use it for correct alignment
+        # Dataloader pre-trims responses per chunk; include any dataset-specific offset.
         if not hasattr(dataset, "frame_overhead") and not hasattr(dataset, "lag"):
             raise ValueError(
                 "Dataset does not have `frame_overhead` or `lag`, which is required for correct alignment when the "
                 "dataloader pre-trims responses."
             )
-        start_trim = getattr(dataset, "frame_overhead", 0) + getattr(dataset, "lag", 0)
+        start_trim = (
+            getattr(dataset, "frame_overhead", 0)
+            + getattr(dataset, "lag", 0)
+            + getattr(dataset, "extra_frame", 0)
+        )
         new_lag = start_trim
-        avg_responses = avg_responses[start_trim : start_trim + model_len]
-        responses_by_trial = responses_by_trial[start_trim : start_trim + model_len]
+        end_trim = start_trim + model_len
+        if end_trim > full_len:
+            raise ValueError(
+                f"Aligned response window exceeds available responses: {start_trim=} {end_trim=} {full_len=}"
+            )
+        avg_responses = avg_responses[start_trim:end_trim]
+        responses_by_trial = responses_by_trial[start_trim:end_trim]
 
     else:
         # Standard case: model output is shorter than full responses by lag in dataloader targets

--- a/openretina/utils/eval_utils.py
+++ b/openretina/utils/eval_utils.py
@@ -263,8 +263,8 @@ class EvaluationSummary:
 def align_responses_to_model_output(
     targets: torch.Tensor | np.ndarray,
     model_responses: torch.Tensor | np.ndarray,
-    avg_responses: torch.Tensor | np.ndarray,
-    responses_by_trial: torch.Tensor | np.ndarray,
+    avg_responses: np.ndarray,
+    responses_by_trial: np.ndarray,
     dataset: torch.utils.data.Dataset,
     lag: int = -1,
 ) -> tuple[np.ndarray, np.ndarray, int]:

--- a/openretina/utils/eval_utils.py
+++ b/openretina/utils/eval_utils.py
@@ -243,7 +243,7 @@ class EvaluationSummary:
             ("Poisson loss", self.poisson_loss_mean),
         ]
         for name, value in metric_values:
-            print(f"  {name:30s}: {value:.4f}")
+            print(f"  {name:30s}: {value:.3f}")
 
         # Per-trial metrics
         if self.filtering_applied and can_filter:
@@ -253,9 +253,9 @@ class EvaluationSummary:
         print("-" * 80)
 
         if not np.isnan(self.corr_by_trial_mean):
-            print(f"  {'Correlation':30s}: {self.corr_by_trial_mean:.4f} (+/-{self.corr_by_trial_std:.4f})")
+            print(f"  {'Correlation':30s}: {self.corr_by_trial_mean:.3f} (+/-{self.corr_by_trial_std:.3f})")
         if not np.isnan(self.mse_by_trial_mean):
-            print(f"  {'MSE':30s}: {self.mse_by_trial_mean:.4f} (+/-{self.mse_by_trial_std:.4f})")
+            print(f"  {'MSE':30s}: {self.mse_by_trial_mean:.3f} (+/-{self.mse_by_trial_std:.3f})")
 
         print("=" * 80)
 


### PR DESCRIPTION
Latest PR broke Sridhar evaluation.
In their case the test dataloader does not use full test chunk size, pre-computes lag, and has a few unused frames at the end. The lag computation used for the rest of the datasets was breaking this. 
I tried to fix it in a bit of a more general sense, in case any other dataloaders will use their pattern in the future.