### PR TITLE
Add readout visualization for all readout layers

### DIFF
--- a/openretina/modules/readout/base.py
+++ b/openretina/modules/readout/base.py
@@ -3,15 +3,18 @@ Adapted from neuralpredictors:
 https://github.com/sinzlab/neuralpredictors/blob/v0.3.0.pre/neuralpredictors/layers/readouts/base.py
 """
 
+import os
 import warnings
+from abc import ABC, abstractmethod
 from typing import Any, Literal, Optional
 
+import matplotlib.pyplot as plt
 import torch
 import torch.nn as nn
 from jaxtyping import Float
 
 
-class Readout(nn.Module):
+class Readout(nn.Module, ABC):
     """
     Base readout class for all individual readouts.
     The MultiReadout will expect its readouts to inherit from this base class.
@@ -68,10 +71,30 @@ class Readout(nn.Module):
     def __repr__(self) -> str:
         return super().__repr__() + " [{}]\n".format(self.__class__.__name__)
 
+    @abstractmethod
+    def plot_weight_for_neuron(self, neuron_id: int, *args: Any, **kwargs: Any) -> plt.Figure:
+        """Visualize the weights contributing to a single neuron."""
+
+    @abstractmethod
+    def number_of_neurons(self) -> int:
+        """Return the number of neurons represented by this readout."""
+
     def save_weight_visualizations(
         self, folder_path: str, file_format: str = "jpg", state_suffix: str = "", *args: Any, **kwargs: Any
     ) -> None:
-        raise NotImplementedError("save_weight_visualizations is not implemented for ", self.__class__.__name__)
+        if not hasattr(self, "outdims"):
+            raise AttributeError(f"{self.__class__.__name__} does not define 'outdims' for saving visualizations.")
+
+        os.makedirs(folder_path, exist_ok=True)
+        suffix = f"_{state_suffix}" if state_suffix else ""
+
+        for neuron_id in range(self.number_of_neurons()):
+            fig = self.plot_weight_for_neuron(neuron_id, *args, **kwargs)
+            fig.tight_layout()
+            plot_path = os.path.join(folder_path, f"neuron_{neuron_id}{suffix}.{file_format}")
+            fig.savefig(plot_path, bbox_inches="tight", facecolor="w", dpi=300)
+            fig.clf()
+            plt.close(fig)
 
 
 class ClonedReadout(Readout):
@@ -102,3 +125,28 @@ class ClonedReadout(Readout):
     def initialize(self, **kwargs: Any) -> None:
         self.alpha.data.fill_(1.0)
         self.beta.data.fill_(0.0)
+
+    def plot_weight_for_neuron(
+        self,
+        neuron_id: int,
+        axes: tuple[plt.Axes, plt.Axes] | None = None,
+        add_titles: bool = True,
+        remove_readout_ticks: bool = False,
+    ) -> plt.Figure:
+        if neuron_id < 0 or neuron_id >= self.outdims:
+            raise IndexError(f"neuron_id={neuron_id} is out of bounds for {self.outdims} neurons")
+
+        fig = self._source.plot_weight_for_neuron(
+            neuron_id,
+            axes=axes,
+            add_titles=add_titles,
+            remove_readout_ticks=remove_readout_ticks,
+        )
+        fig.suptitle(
+            f"Cloned readout: alpha={self.alpha[neuron_id].item():.3g}, beta={self.beta[neuron_id].item():.3g}",
+            fontsize=10,
+        )
+        return fig
+
+    def number_of_neurons(self) -> int:
+        return self.outdims

--- a/openretina/modules/readout/base.py
+++ b/openretina/modules/readout/base.py
@@ -100,12 +100,22 @@ class Readout(nn.Module, ABC):
         """Return the number of neurons represented by this readout."""
 
     def save_weight_visualizations(
-        self, folder_path: str, file_format: str = "jpg", state_suffix: str = "", *args: Any, **kwargs: Any
+        self,
+        folder_path: str,
+        file_format: str = "jpg",
+        state_suffix: str = "",
+        cell_indices: list[int] | None = None,
+        *args: Any,
+        **kwargs: Any
     ) -> None:
         os.makedirs(folder_path, exist_ok=True)
         suffix = f"_{state_suffix}" if state_suffix else ""
 
-        for neuron_id in range(self.number_of_neurons()):
+        if cell_indices is None:
+            indices_to_plot = list(range(self.number_of_neurons()))
+        else:
+            indices_to_plot = cell_indices
+        for neuron_id in indices_to_plot:
             fig = self.plot_weight_for_neuron(neuron_id, *args, **kwargs)
             fig.tight_layout()
             plot_path = os.path.join(folder_path, f"neuron_{neuron_id}{suffix}.{file_format}")
@@ -160,4 +170,4 @@ class ClonedReadout(Readout):
         )
 
     def number_of_neurons(self) -> int:
-        return self.outdims
+        return self._source.number_of_neurons()

--- a/openretina/modules/readout/base.py
+++ b/openretina/modules/readout/base.py
@@ -71,8 +71,28 @@ class Readout(nn.Module, ABC):
     def __repr__(self) -> str:
         return super().__repr__() + " [{}]\n".format(self.__class__.__name__)
 
+    def plot_weight_for_neuron(
+        self,
+        neuron_id: int,
+        axes: tuple[plt.Axes, plt.Axes] | None = None,
+        remove_readout_ticks: bool = False,
+        add_titles: bool = True,
+    ) -> plt.Figure:
+        """Visualize the weights contributing to a single neuron."""
+        if neuron_id < 0 or neuron_id >= self.number_of_neurons():
+            raise IndexError(f"neuron_id={neuron_id} is out of bounds for {self.number_of_neurons()} neurons")
+        if axes is None:
+            fig, (ax_readout, ax_features) = plt.subplots(ncols=2, figsize=(12, 6))
+        else:
+            ax_readout, ax_features = axes
+        self._plot_weight_for_neuron(neuron_id, axes=(ax_readout, ax_features), add_titles=add_titles)
+        if remove_readout_ticks:
+            ax_features.axes.get_xaxis().set_ticks([])
+            ax_features.axes.get_yaxis().set_ticks([])
+        return ax_readout.figure
+
     @abstractmethod
-    def plot_weight_for_neuron(self, neuron_id: int, *args: Any, **kwargs: Any) -> plt.Figure:
+    def _plot_weight_for_neuron(self, neuron_id: int, axes: tuple[plt.Axes, plt.Axes], add_titles: bool) -> None:
         """Visualize the weights contributing to a single neuron."""
 
     @abstractmethod
@@ -82,9 +102,6 @@ class Readout(nn.Module, ABC):
     def save_weight_visualizations(
         self, folder_path: str, file_format: str = "jpg", state_suffix: str = "", *args: Any, **kwargs: Any
     ) -> None:
-        if not hasattr(self, "outdims"):
-            raise AttributeError(f"{self.__class__.__name__} does not define 'outdims' for saving visualizations.")
-
         os.makedirs(folder_path, exist_ok=True)
         suffix = f"_{state_suffix}" if state_suffix else ""
 
@@ -126,27 +143,21 @@ class ClonedReadout(Readout):
         self.alpha.data.fill_(1.0)
         self.beta.data.fill_(0.0)
 
-    def plot_weight_for_neuron(
+    def _plot_weight_for_neuron(
         self,
         neuron_id: int,
-        axes: tuple[plt.Axes, plt.Axes] | None = None,
+        axes: tuple[plt.Axes, plt.Axes],
         add_titles: bool = True,
-        remove_readout_ticks: bool = False,
-    ) -> plt.Figure:
-        if neuron_id < 0 or neuron_id >= self.outdims:
-            raise IndexError(f"neuron_id={neuron_id} is out of bounds for {self.outdims} neurons")
-
+    ) -> None:
         fig = self._source.plot_weight_for_neuron(
             neuron_id,
             axes=axes,
             add_titles=add_titles,
-            remove_readout_ticks=remove_readout_ticks,
         )
         fig.suptitle(
             f"Cloned readout: alpha={self.alpha[neuron_id].item():.3g}, beta={self.beta[neuron_id].item():.3g}",
             fontsize=10,
         )
-        return fig
 
     def number_of_neurons(self) -> int:
         return self.outdims

--- a/openretina/modules/readout/base.py
+++ b/openretina/modules/readout/base.py
@@ -106,7 +106,7 @@ class Readout(nn.Module, ABC):
         state_suffix: str = "",
         cell_indices: list[int] | None = None,
         *args: Any,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> None:
         os.makedirs(folder_path, exist_ok=True)
         suffix = f"_{state_suffix}" if state_suffix else ""

--- a/openretina/modules/readout/factorized.py
+++ b/openretina/modules/readout/factorized.py
@@ -202,28 +202,6 @@ class FactorizedReadout(Readout):
     def number_of_neurons(self) -> int:
         return self.outdims
 
-    def save_weight_visualizations(
-        self, folder_path: str, file_format: str = "jpg", state_suffix: str = "", cell_indices: list[int] | None = None
-    ) -> None:
-        if cell_indices is None:
-            super().save_weight_visualizations(folder_path, file_format, state_suffix)
-            return
-
-        os.makedirs(folder_path, exist_ok=True)
-        suffix = f"_{state_suffix}" if state_suffix else ""
-        selected_indices = [i for i in cell_indices if 0 <= i < self.outdims]
-        for neuron_id in selected_indices:
-            fig = self.plot_weight_for_neuron(neuron_id)
-            fig.tight_layout()
-            fig.savefig(
-                os.path.join(folder_path, f"neuron_{neuron_id}{suffix}.{file_format}"),
-                bbox_inches="tight",
-                facecolor="w",
-                dpi=300,
-            )
-            fig.clf()
-            plt.close(fig)
-
     def initialize(self, mean_activity: Float[torch.Tensor, " outdims"] | None = None) -> None:
         if mean_activity is not None:
             self.initialize_bias(mean_activity)

--- a/openretina/modules/readout/factorized.py
+++ b/openretina/modules/readout/factorized.py
@@ -171,20 +171,13 @@ class FactorizedReadout(Readout):
         h, w = self.mask_size
         return self.mask_weights.T.view(-1, h, w)
 
-    def plot_weight_for_neuron(
+    def _plot_weight_for_neuron(
         self,
         neuron_id: int,
-        axes: tuple[plt.Axes, plt.Axes] | None = None,
+        axes: tuple[plt.Axes, plt.Axes],
         add_titles: bool = True,
-        remove_readout_ticks: bool = False,
-    ) -> plt.Figure:
-        if neuron_id < 0 or neuron_id >= self.outdims:
-            raise IndexError(f"neuron_id={neuron_id} is out of bounds for {self.outdims} neurons")
-
-        if axes is None:
-            fig, (ax_readout, ax_features) = plt.subplots(ncols=2, figsize=(12, 6))
-        else:
-            ax_readout, ax_features = axes
+    ) -> None:
+        ax_readout, ax_features = axes
 
         masks = self._spatial_masks().detach().cpu().numpy()
         features = self.feature_weights.detach().cpu().numpy()
@@ -197,21 +190,14 @@ class FactorizedReadout(Readout):
             cmap="RdBu_r",
             norm=Normalize(-mask_abs_max, mask_abs_max),
         )
-        ax_readout.axes.get_xaxis().set_ticks([])
-        ax_readout.axes.get_yaxis().set_ticks([])
 
         features_neuron = features[:, neuron_id]
         ax_features.bar(range(features_neuron.shape[0]), features_neuron)
         ax_features.set_ylim((-feature_abs_max, feature_abs_max))
-        if remove_readout_ticks:
-            ax_features.axes.get_xaxis().set_ticks([])
-            ax_features.axes.get_yaxis().set_ticks([])
 
         if add_titles:
             ax_readout.set_title("Readout Mask")
             ax_features.set_title("Readout Feature Weights")
-
-        return ax_readout.figure
 
     def number_of_neurons(self) -> int:
         return self.outdims

--- a/openretina/modules/readout/factorized.py
+++ b/openretina/modules/readout/factorized.py
@@ -1,4 +1,3 @@
-import os
 from typing import Any, Literal, Optional, Sequence
 
 import matplotlib.pyplot as plt
@@ -207,5 +206,6 @@ class FactorizedReadout(Readout):
             self.initialize_bias(mean_activity)
 
 
+# Alias for backward compatibility
 class KlindtReadoutWrapper3D(FactorizedReadout):
     pass

--- a/openretina/modules/readout/factorized.py
+++ b/openretina/modules/readout/factorized.py
@@ -1,12 +1,13 @@
 import os
-from math import ceil, sqrt
 from typing import Any, Literal, Optional, Sequence
 
 import matplotlib.pyplot as plt
+import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from jaxtyping import Float
+from matplotlib.colors import Normalize
 
 from openretina.modules.layers import FlatLaplaceL23dnorm
 from openretina.modules.readout.base import Readout
@@ -166,91 +167,81 @@ class FactorizedReadout(Readout):
         else:
             return mask_r + wt_r + laplace_mask_r
 
+    def _spatial_masks(self) -> torch.Tensor:
+        h, w = self.mask_size
+        return self.mask_weights.T.view(-1, h, w)
+
+    def plot_weight_for_neuron(
+        self,
+        neuron_id: int,
+        axes: tuple[plt.Axes, plt.Axes] | None = None,
+        add_titles: bool = True,
+        remove_readout_ticks: bool = False,
+    ) -> plt.Figure:
+        if neuron_id < 0 or neuron_id >= self.outdims:
+            raise IndexError(f"neuron_id={neuron_id} is out of bounds for {self.outdims} neurons")
+
+        if axes is None:
+            fig, (ax_readout, ax_features) = plt.subplots(ncols=2, figsize=(12, 6))
+        else:
+            ax_readout, ax_features = axes
+
+        masks = self._spatial_masks().detach().cpu().numpy()
+        features = self.feature_weights.detach().cpu().numpy()
+        mask_abs_max = float(np.abs(masks).max()) or 1.0
+        feature_abs_max = float(np.abs(features).max()) or 1.0
+
+        ax_readout.imshow(
+            masks[neuron_id],
+            interpolation="none",
+            cmap="RdBu_r",
+            norm=Normalize(-mask_abs_max, mask_abs_max),
+        )
+        ax_readout.axes.get_xaxis().set_ticks([])
+        ax_readout.axes.get_yaxis().set_ticks([])
+
+        features_neuron = features[:, neuron_id]
+        ax_features.bar(range(features_neuron.shape[0]), features_neuron)
+        ax_features.set_ylim((-feature_abs_max, feature_abs_max))
+        if remove_readout_ticks:
+            ax_features.axes.get_xaxis().set_ticks([])
+            ax_features.axes.get_yaxis().set_ticks([])
+
+        if add_titles:
+            ax_readout.set_title("Readout Mask")
+            ax_features.set_title("Readout Feature Weights")
+
+        return ax_readout.figure
+
+    def number_of_neurons(self) -> int:
+        return self.outdims
+
     def save_weight_visualizations(
         self, folder_path: str, file_format: str = "jpg", state_suffix: str = "", cell_indices: list[int] | None = None
     ) -> None:
-        if hasattr(self, "mask_size"):
-            H, W = self.mask_size
-        else:
-            raise AttributeError("Model does not have attribute 'mask_size'.")
+        if cell_indices is None:
+            super().save_weight_visualizations(folder_path, file_format, state_suffix)
+            return
 
-        readout = self
-        if hasattr(readout, "mask_weights"):  # nn.Parameter & matmul
-            weights = dict(readout.named_parameters())["mask_weights"].detach().cpu()
-            weights = weights.T.view(-1, H, W)  # [num_neurons, H, W]
-        elif hasattr(readout, "mask"):  # nn.Linear
-            weights = dict(readout.named_parameters())["mask.weight"].detach().cpu()
-            weights = weights.view(-1, H, W)
-        else:
-            raise AttributeError("Model does not have 'mask_weights' or 'feature_weights'.")
-
-        total_neurons = weights.shape[0]
-        if not cell_indices:
-            cell_indices = list(range(total_neurons))
-        else:
-            cell_indices = [i for i in cell_indices if 0 <= i < total_neurons]
-
-        selected_weights = weights[cell_indices]
-        n_cells = selected_weights.shape[0]
-
-        grid_cols = min(8, ceil(sqrt(n_cells)))
-        grid_rows = ceil(n_cells / grid_cols)
-
-        fig, axes = plt.subplots(grid_rows, grid_cols, figsize=(1.5 * grid_cols, 1.5 * grid_rows))
-
-        if n_cells == 1:
-            axes = [axes]
-        else:
-            axes = axes.flatten()
-
-        vmin = torch.min(selected_weights).item()
-        vmax = torch.max(selected_weights).item()
-
-        for i, ax in enumerate(axes):
-            if i < n_cells:
-                ax.imshow(selected_weights[i], interpolation="bicubic", cmap="gray", vmin=vmin, vmax=vmax)
-                ax.set_xticks([])
-                ax.set_yticks([])
-            else:
-                ax.axis("off")
-
-        fig.suptitle("Spatial Masks", fontsize=14)
-        fig.tight_layout()
-        fig.savefig(
-            os.path.join(folder_path, "readout_masks_" + state_suffix + f".{file_format}"),
-            bbox_inches="tight",
-            facecolor="w",
-            dpi=300,
-        )
-        fig.clf()
-        plt.close()
-
-        # Feature weights
-        feature_weights = readout.feature_weights.detach().cpu()
-        feature_weights_np = feature_weights.numpy()
-
-        fig, ax = plt.subplots(figsize=(8, 6))
-        im = ax.imshow(feature_weights_np, aspect="auto", cmap="gray")
-        ax.set_title("Feature Weights (channels × neurons)")
-        ax.set_xlabel("Neuron")
-        ax.set_ylabel("Feature Channel")
-        fig.colorbar(im, ax=ax)
-        fig.tight_layout()
-
-        fig.savefig(
-            os.path.join(folder_path, "feature_weights_" + state_suffix + f".{file_format}"),
-            bbox_inches="tight",
-            facecolor="w",
-            dpi=300,
-        )
-        fig.clf()
-        plt.close()
+        os.makedirs(folder_path, exist_ok=True)
+        suffix = f"_{state_suffix}" if state_suffix else ""
+        selected_indices = [i for i in cell_indices if 0 <= i < self.outdims]
+        for neuron_id in selected_indices:
+            fig = self.plot_weight_for_neuron(neuron_id)
+            fig.tight_layout()
+            fig.savefig(
+                os.path.join(folder_path, f"neuron_{neuron_id}{suffix}.{file_format}"),
+                bbox_inches="tight",
+                facecolor="w",
+                dpi=300,
+            )
+            fig.clf()
+            plt.close(fig)
 
     def initialize(self, mean_activity: Float[torch.Tensor, " outdims"] | None = None) -> None:
         if mean_activity is not None:
             self.initialize_bias(mean_activity)
 
 
-# Alias for backward compatibility
 class KlindtReadoutWrapper3D(FactorizedReadout):
     pass

--- a/openretina/modules/readout/factorized_gaussian.py
+++ b/openretina/modules/readout/factorized_gaussian.py
@@ -204,15 +204,10 @@ class GaussianMaskReadout(Readout):
             ax_readout.set_title("Readout Mask")
             ax_features.set_title("Readout Feature Weights")
 
-        return plt.gcf()
+        return ax_readout.figure
+
+    def number_of_neurons(self) -> int:
+        return self.outdims
 
     def save_weight_visualizations(self, folder_path: str, file_format: str = "jpg", state_suffix: str = "") -> None:
-        for neuron_id in range(self.outdims):
-            fig_axes_tuple = plt.subplots(ncols=2, figsize=(2 * 6, 6))
-            axes: tuple[plt.Axes, plt.Axes] = fig_axes_tuple[1]  # type: ignore
-            self.plot_weight_for_neuron(neuron_id, axes)
-
-            plot_path = f"{folder_path}/neuron_{neuron_id}_{state_suffix}.{file_format}"
-            fig_axes_tuple[0].savefig(plot_path, bbox_inches="tight", facecolor="w", dpi=300)
-            fig_axes_tuple[0].clf()
-            plt.close()
+        super().save_weight_visualizations(folder_path, file_format, state_suffix)

--- a/openretina/modules/readout/factorized_gaussian.py
+++ b/openretina/modules/readout/factorized_gaussian.py
@@ -171,18 +171,13 @@ class GaussianMaskReadout(Readout):
         res_array.append(children_string)
         return "\n".join(res_array)
 
-    def plot_weight_for_neuron(
+    def _plot_weight_for_neuron(
         self,
         neuron_id: int,
-        axes: tuple[plt.Axes, plt.Axes] | None = None,
+        axes: tuple[plt.Axes, plt.Axes],
         add_titles: bool = True,
-        remove_readout_ticks: bool = False,
-    ) -> plt.Figure:
-        if axes is None:
-            fig_axes_tuple = plt.subplots(ncols=2, figsize=(2 * 6, 6))
-            ax_readout, ax_features = fig_axes_tuple[1]  # type: ignore
-        else:
-            ax_readout, ax_features = axes
+    ) -> None:
+        ax_readout, ax_features = axes
 
         masks = self.get_mask().detach().cpu().numpy()
         features = self.features.detach().cpu().numpy()
@@ -190,24 +185,14 @@ class GaussianMaskReadout(Readout):
         mask_neuron = masks[neuron_id, :, :]
 
         ax_readout.imshow(mask_neuron, interpolation="none", cmap="RdBu_r", norm=Normalize(-mask_abs_max, mask_abs_max))
-        ax_readout.axes.get_xaxis().set_ticks([])
-        ax_readout.axes.get_yaxis().set_ticks([])
 
         features_neuron = features[0, :, 0, neuron_id]
         ax_features.bar(range(features_neuron.shape[0]), features_neuron)
         ax_features.set_ylim((features.min(), features.max()))
-        if remove_readout_ticks:
-            ax_features.axes.get_xaxis().set_ticks([])
-            ax_features.axes.get_yaxis().set_ticks([])
 
         if add_titles:
             ax_readout.set_title("Readout Mask")
             ax_features.set_title("Readout Feature Weights")
 
-        return ax_readout.figure
-
     def number_of_neurons(self) -> int:
         return self.outdims
-
-    def save_weight_visualizations(self, folder_path: str, file_format: str = "jpg", state_suffix: str = "") -> None:
-        super().save_weight_visualizations(folder_path, file_format, state_suffix)

--- a/openretina/modules/readout/gaussian.py
+++ b/openretina/modules/readout/gaussian.py
@@ -411,8 +411,6 @@ class PointGaussianReadout(Readout):
             y = y + bias
         return y
 
-
-
     def _neuron_covariance(self, neuron_id: int) -> torch.Tensor:
         sigma = self.sigma.detach().cpu()[0, neuron_id]
         if self.gauss_type == "full":
@@ -441,20 +439,13 @@ class PointGaussianReadout(Readout):
         density = density / density.sum().clamp_min(1e-8)
         return density.numpy()
 
-    def plot_weight_for_neuron(
+    def _plot_weight_for_neuron(
         self,
         neuron_id: int,
-        axes: tuple[plt.Axes, plt.Axes] | None = None,
+        axes: tuple[plt.Axes, plt.Axes],
         add_titles: bool = True,
-        remove_readout_ticks: bool = False,
-    ) -> plt.Figure:
-        if neuron_id < 0 or neuron_id >= self.outdims:
-            raise IndexError(f"neuron_id={neuron_id} is out of bounds for {self.outdims} neurons")
-
-        if axes is None:
-            _, (ax_readout, ax_features) = plt.subplots(ncols=2, figsize=(12, 6))
-        else:
-            ax_readout, ax_features = axes
+    ) -> None:
+        ax_readout, ax_features = axes
 
         density = self._neuron_sampling_map(neuron_id)
         mu = self.mu.detach().cpu().numpy()[0, neuron_id, 0]
@@ -465,21 +456,14 @@ class PointGaussianReadout(Readout):
         x_pixel = (mu[0] + 1.0) * (density.shape[1] - 1) / 2.0
         y_pixel = (mu[1] + 1.0) * (density.shape[0] - 1) / 2.0
         ax_readout.scatter(x_pixel, y_pixel, c="white", edgecolors="black", s=40)
-        ax_readout.axes.get_xaxis().set_ticks([])
-        ax_readout.axes.get_yaxis().set_ticks([])
 
         features_neuron = features[:, neuron_id]
         ax_features.bar(range(features_neuron.shape[0]), features_neuron)
         ax_features.set_ylim((-feature_abs_max, feature_abs_max))
-        if remove_readout_ticks:
-            ax_features.axes.get_xaxis().set_ticks([])
-            ax_features.axes.get_yaxis().set_ticks([])
 
         if add_titles:
             ax_readout.set_title("Sampling Density")
             ax_features.set_title("Readout Feature Weights")
-
-        return ax_readout.figure
 
     def number_of_neurons(self) -> int:
         return self.outdims
@@ -501,6 +485,7 @@ class PointGaussianReadout(Readout):
         for ch in self.children():
             r += "  -> " + ch.__repr__() + "\n"
         return r
+
 
 # Alias for backward compatibility
 class FullGaussian2d(PointGaussianReadout):

--- a/openretina/modules/readout/gaussian.py
+++ b/openretina/modules/readout/gaussian.py
@@ -2,6 +2,7 @@
 # Original code: https://github.com/sinzlab/neuralpredictors/blob/main/neuralpredictors/layers/readouts/gaussian.py
 import warnings
 
+import matplotlib.pyplot as plt
 import numpy as np
 import torch
 from torch import nn
@@ -410,6 +411,79 @@ class PointGaussianReadout(Readout):
             y = y + bias
         return y
 
+
+
+    def _neuron_covariance(self, neuron_id: int) -> torch.Tensor:
+        sigma = self.sigma.detach().cpu()[0, neuron_id]
+        if self.gauss_type == "full":
+            covariance = sigma @ sigma.T
+        elif self.gauss_type == "uncorrelated":
+            std = sigma.view(-1)
+            covariance = torch.diag(std.square())
+        else:
+            std = sigma.view(-1)[0]
+            covariance = torch.eye(2) * std.square()
+        return covariance + 1e-6 * torch.eye(2)
+
+    def _neuron_sampling_map(self, neuron_id: int) -> np.ndarray:
+        _, _, height, width = self.in_shape
+        x_coords = torch.linspace(-1.0, 1.0, width)
+        y_coords = torch.linspace(-1.0, 1.0, height)
+        yy, xx = torch.meshgrid(y_coords, x_coords, indexing="ij")
+        positions = torch.stack([xx, yy], dim=-1)
+
+        mu = self.mu.detach().cpu()[0, neuron_id, 0]
+        covariance = self._neuron_covariance(neuron_id)
+        covariance_inv = torch.linalg.pinv(covariance)
+        centered = positions - mu
+        mahalanobis = torch.einsum("...i,ij,...j->...", centered, covariance_inv, centered)
+        density = torch.exp(-0.5 * mahalanobis)
+        density = density / density.sum().clamp_min(1e-8)
+        return density.numpy()
+
+    def plot_weight_for_neuron(
+        self,
+        neuron_id: int,
+        axes: tuple[plt.Axes, plt.Axes] | None = None,
+        add_titles: bool = True,
+        remove_readout_ticks: bool = False,
+    ) -> plt.Figure:
+        if neuron_id < 0 or neuron_id >= self.outdims:
+            raise IndexError(f"neuron_id={neuron_id} is out of bounds for {self.outdims} neurons")
+
+        if axes is None:
+            _, (ax_readout, ax_features) = plt.subplots(ncols=2, figsize=(12, 6))
+        else:
+            ax_readout, ax_features = axes
+
+        density = self._neuron_sampling_map(neuron_id)
+        mu = self.mu.detach().cpu().numpy()[0, neuron_id, 0]
+        features = self.features.detach().cpu().numpy()[0, :, 0, :]
+        feature_abs_max = float(np.abs(features).max()) or 1.0
+
+        ax_readout.imshow(density, interpolation="nearest", cmap="viridis")
+        x_pixel = (mu[0] + 1.0) * (density.shape[1] - 1) / 2.0
+        y_pixel = (mu[1] + 1.0) * (density.shape[0] - 1) / 2.0
+        ax_readout.scatter(x_pixel, y_pixel, c="white", edgecolors="black", s=40)
+        ax_readout.axes.get_xaxis().set_ticks([])
+        ax_readout.axes.get_yaxis().set_ticks([])
+
+        features_neuron = features[:, neuron_id]
+        ax_features.bar(range(features_neuron.shape[0]), features_neuron)
+        ax_features.set_ylim((-feature_abs_max, feature_abs_max))
+        if remove_readout_ticks:
+            ax_features.axes.get_xaxis().set_ticks([])
+            ax_features.axes.get_yaxis().set_ticks([])
+
+        if add_titles:
+            ax_readout.set_title("Sampling Density")
+            ax_features.set_title("Readout Feature Weights")
+
+        return ax_readout.figure
+
+    def number_of_neurons(self) -> int:
+        return self.outdims
+
     def __repr__(self):
         c, _, w, h = self.in_shape
         r = self.gauss_type + " "
@@ -427,7 +501,6 @@ class PointGaussianReadout(Readout):
         for ch in self.children():
             r += "  -> " + ch.__repr__() + "\n"
         return r
-
 
 # Alias for backward compatibility
 class FullGaussian2d(PointGaussianReadout):

--- a/openretina/modules/readout/linear_nonlinear_poison.py
+++ b/openretina/modules/readout/linear_nonlinear_poison.py
@@ -1,11 +1,16 @@
+from math import ceil, sqrt
+
+import matplotlib.pyplot as plt
+import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from einops import rearrange
 from jaxtyping import Float, Int
+from matplotlib.colors import Normalize
 
 from openretina.modules.layers import regularizers
-from openretina.modules.readout.multi_readout import Readout
+from openretina.modules.readout.base import Readout
 
 
 class LNPReadout(Readout):
@@ -77,6 +82,66 @@ class LNPReadout(Readout):
 
     def regularizer(self, **kwargs):
         return self.smooth_weight * self.laplace() + self.sparse_weight * self.weights_l1()
+
+    @staticmethod
+    def _build_channel_montage(channel_weights: np.ndarray, padding: int = 1) -> np.ndarray:
+        n_channels, height, width = channel_weights.shape
+        n_cols = max(1, ceil(sqrt(n_channels)))
+        n_rows = ceil(n_channels / n_cols)
+        montage_height = n_rows * height + padding * (n_rows - 1)
+        montage_width = n_cols * width + padding * (n_cols - 1)
+        montage = np.zeros((montage_height, montage_width), dtype=channel_weights.dtype)
+
+        for idx, kernel in enumerate(channel_weights):
+            row, col = divmod(idx, n_cols)
+            row_start = row * (height + padding)
+            col_start = col * (width + padding)
+            montage[row_start : row_start + height, col_start : col_start + width] = kernel
+
+        return montage
+
+    def plot_weight_for_neuron(
+        self,
+        neuron_id: int,
+        axes: tuple[plt.Axes, plt.Axes] | None = None,
+        add_titles: bool = True,
+        remove_readout_ticks: bool = False,
+    ) -> plt.Figure:
+        if neuron_id < 0 or neuron_id >= self.outdims:
+            raise IndexError(f"neuron_id={neuron_id} is out of bounds for {self.outdims} neurons")
+
+        if axes is None:
+            fig, (ax_readout, ax_features) = plt.subplots(ncols=2, figsize=(12, 6))
+        else:
+            ax_readout, ax_features = axes
+
+        weights = self.inner_product_kernel.weight.detach().cpu().numpy()[neuron_id, :, 0, :, :]
+        weight_abs_max = float(np.abs(weights).max()) or 1.0
+        montage = self._build_channel_montage(weights)
+        channel_norms = np.linalg.norm(weights.reshape(weights.shape[0], -1), axis=1)
+
+        ax_readout.imshow(
+            montage,
+            interpolation="none",
+            cmap="RdBu_r",
+            norm=Normalize(-weight_abs_max, weight_abs_max),
+        )
+        ax_readout.axes.get_xaxis().set_ticks([])
+        ax_readout.axes.get_yaxis().set_ticks([])
+
+        ax_features.bar(range(channel_norms.shape[0]), channel_norms)
+        if remove_readout_ticks:
+            ax_features.axes.get_xaxis().set_ticks([])
+            ax_features.axes.get_yaxis().set_ticks([])
+
+        if add_titles:
+            ax_readout.set_title("Per-Channel Spatial Kernels")
+            ax_features.set_title("Kernel Norm per Channel")
+
+        return ax_readout.figure
+
+    def number_of_neurons(self) -> int:
+        return self.n_neurons
 
     def initialize(self, mean_activity: Float[torch.Tensor, " n_neurons"] | None = None) -> None:
         if self.inner_product_kernel.bias is not None and mean_activity is not None:

--- a/openretina/modules/readout/linear_nonlinear_poison.py
+++ b/openretina/modules/readout/linear_nonlinear_poison.py
@@ -100,20 +100,13 @@ class LNPReadout(Readout):
 
         return montage
 
-    def plot_weight_for_neuron(
+    def _plot_weight_for_neuron(
         self,
         neuron_id: int,
-        axes: tuple[plt.Axes, plt.Axes] | None = None,
+        axes: tuple[plt.Axes, plt.Axes],
         add_titles: bool = True,
-        remove_readout_ticks: bool = False,
-    ) -> plt.Figure:
-        if neuron_id < 0 or neuron_id >= self.outdims:
-            raise IndexError(f"neuron_id={neuron_id} is out of bounds for {self.outdims} neurons")
-
-        if axes is None:
-            fig, (ax_readout, ax_features) = plt.subplots(ncols=2, figsize=(12, 6))
-        else:
-            ax_readout, ax_features = axes
+    ) -> None:
+        ax_readout, ax_features = axes
 
         weights = self.inner_product_kernel.weight.detach().cpu().numpy()[neuron_id, :, 0, :, :]
         weight_abs_max = float(np.abs(weights).max()) or 1.0
@@ -126,19 +119,11 @@ class LNPReadout(Readout):
             cmap="RdBu_r",
             norm=Normalize(-weight_abs_max, weight_abs_max),
         )
-        ax_readout.axes.get_xaxis().set_ticks([])
-        ax_readout.axes.get_yaxis().set_ticks([])
-
         ax_features.bar(range(channel_norms.shape[0]), channel_norms)
-        if remove_readout_ticks:
-            ax_features.axes.get_xaxis().set_ticks([])
-            ax_features.axes.get_yaxis().set_ticks([])
 
         if add_titles:
             ax_readout.set_title("Per-Channel Spatial Kernels")
             ax_features.set_title("Kernel Norm per Channel")
-
-        return ax_readout.figure
 
     def number_of_neurons(self) -> int:
         return self.n_neurons


### PR DESCRIPTION
Previous, the example to plot the readout weights mentioned in the [documentation](https://open-retina.org/package_docs/insilico/weight_visualisations/) did not work for "hoefling_2024_low_res" as the PointGaussianReadout did not implement the plotting function.

Now it plots the following for the "hoefling_2024_low_res" model:
<img width="1200" height="600" alt="readout_weight_hoefling_2024_low_res" src="https://github.com/user-attachments/assets/7058dc5b-565e-4483-ab65-e6e53f079d64" />

I also made the Readout class an abstract class which enforces that certain methods have to be implemented in all subclasses. I implemented the feature visualization for all readout subclasses, too.

Here's how it looks for other models:

## GaussianMaskReadout

<img width="1200" height="600" alt="base_readout" src="https://github.com/user-attachments/assets/122adba3-22aa-49ba-bd07-ad2aa7e533e0" />


## FactorizedReadout (randomly initialized with unusual params)

<img width="1200" height="600" alt="Figure_2" src="https://github.com/user-attachments/assets/134e64e5-8a25-4593-adaf-d404b58cc788" />

## LNPReadout (randomly initialized)

<img width="1200" height="600" alt="Figure_3" src="https://github.com/user-attachments/assets/041411f1-6a69-46e9-a3f8-ea2a126851b5" />


