### PR TITLE
Set weights_only=False during model loading to support newer torch versions

### DIFF
--- a/openretina/models/core_readout.py
+++ b/openretina/models/core_readout.py
@@ -515,10 +515,10 @@ def load_core_readout_from_remote(
     remote_path = _MODEL_NAME_TO_REMOTE_LOCATION.get(model_path, model_path)
     local_path = get_local_file_path(remote_path, cache_directory_path)
     try:
-        return UnifiedCoreReadout.load_from_checkpoint(local_path, map_location=device)
+        return UnifiedCoreReadout.load_from_checkpoint(local_path, map_location=device, weights_only=False)
     except:  # noqa: E722
         # Support for legacy ExampleCoreReadout model
-        return ExampleCoreReadout.load_from_checkpoint(local_path, map_location=device)
+        return ExampleCoreReadout.load_from_checkpoint(local_path, map_location=device, weights_only=False)
 
 
 def load_core_readout_model(

--- a/openretina/models/core_readout.py
+++ b/openretina/models/core_readout.py
@@ -533,7 +533,7 @@ def load_core_readout_model(
 
     local_path = get_local_file_path(model_path_or_name, cache_directory_path)
     try:
-        return UnifiedCoreReadout.load_from_checkpoint(local_path, map_location=device)
+        return UnifiedCoreReadout.load_from_checkpoint(local_path, map_location=device, weights_only=False)
     except:  # noqa: E722
         # Support for legacy ExampleCoreReadout model
-        return ExampleCoreReadout.load_from_checkpoint(local_path, map_location=device)
+        return ExampleCoreReadout.load_from_checkpoint(local_path, map_location=device, weights_only=False)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openretina"
-version = "1.1.0"
+version = "1.1.1"
 authors = [
     { name = "Federico D'Agostino" },
     { name = "Thomas Zenkel" },


### PR DESCRIPTION
Loading the example checkpoint failed with this error previously:
```
UnifiedCoreReadout.load_from_checkpoint(local_path, map_location=device)
*** _pickle.UnpicklingError: Weights only load failed. This file can still be loaded, to do so you have two options, do those steps only if you trust the source of the checkpoint. 
	(1) In PyTorch 2.6, we changed the default value of the `weights_only` argument in `torch.load` from `False` to `True`. Re-running `torch.load` with `weights_only` set to `False` will likely succeed, but it can result in arbitrary code execution. Do it only if you got the file from a trusted source.
	(2) Alternatively, to load with `weights_only=True` please check the recommended steps in the following error message.
	WeightsUnpickler error: Unsupported global: GLOBAL omegaconf.listconfig.ListConfig was not an allowed global by default. Please use `torch.serialization.add_safe_globals([omegaconf.listconfig.ListConfig])` or the `torch.serialization.safe_globals([omegaconf.listconfig.ListConfig])` context manager to allowlist this global if you trust this class/function.

Check the documentation of torch.load to learn more about types accepted by default with weights_only https://pytorch.org/docs/stable/generated/torch.load.html.
```