### PR TITLE
Debug/laplace1d

### DIFF
--- a/configs/model/single_cell_lnp.yaml
+++ b/configs/model/single_cell_lnp.yaml
@@ -10,7 +10,7 @@ smooth_weight_spat: 1.0
 smooth_weight_temp: 1.0
 sparse_weight: 1.0
 smooth_regularizer_spat: "LaplaceL2norm"
-smooth_regularizer_temp: "Laplace1d"
+smooth_regularizer_temp: "TimeLaplaceL23dnorm"
 laplace_padding: null
 fit_gaussian: false
 normalize_weights: false

--- a/openretina/models/linear_nonlinear.py
+++ b/openretina/models/linear_nonlinear.py
@@ -69,7 +69,7 @@ class SingleCellSeparatedLNP(LightningModule):
     nonlinearity:
         Output nonlinearity applied after the temporal stage. If "parametrized_softplus",
         uses `ParametrizedSoftplus()`. Otherwise, uses `torch.nn.functional.<nonlinearity>`
-        via `F.__dict__[nonlinearity]` (e.g. "exp", "softplus", ...).
+        via `F.__dict__[nonlinearity]` (e.g. "softplus", ...).
     normalize_weights:
         If True, renormalizes spatial and temporal kernels to unit norm at every
         forward pass (in-place, under no_grad).
@@ -122,10 +122,10 @@ class SingleCellSeparatedLNP(LightningModule):
         smooth_weight_temp: float = 0.0,
         sparse_weight: float = 0.0,
         smooth_regularizer_spat: str = "LaplaceL2norm",
-        smooth_regularizer_temp: str = "Laplace1d",
+        smooth_regularizer_temp: str = "TimeLaplaceL23dnorm",
         smooth_regularizer: str = "LaplaceL2norm",
         laplace_padding=None,
-        nonlinearity: str = "exp",
+        nonlinearity: str = "parametrized_softplus",
         normalize_weights: bool = True,
         loss=None,
         evaluation_loss=None,
@@ -263,7 +263,7 @@ class SingleCellSeparatedLNP(LightningModule):
     def laplace(self):
         return self.smooth_weight_spat * self._smooth_reg_fn_spat(
             self.space_conv.weight.squeeze(2)
-        ) + self.smooth_weight_temp * self._smooth_reg_fn_temp(self.time_conv.weight.squeeze(-1, -2))
+        ) + self.smooth_weight_temp * self._smooth_reg_fn_temp(self.time_conv.weight)
 
     def weights_l1(self, average: bool = True):
         """Returns l1 regularization across all weight dimensions

--- a/openretina/modules/core/base_core.py
+++ b/openretina/modules/core/base_core.py
@@ -9,7 +9,7 @@ from matplotlib import pyplot as plt
 from openretina.modules.layers import FlatLaplaceL23dnorm
 from openretina.modules.layers.convolutions import get_conv_class
 from openretina.modules.layers.reducers import WeightedChannelSumLayer
-from openretina.modules.layers.regularizers import  TimeLaplaceL23dnorm
+from openretina.modules.layers.regularizers import TimeLaplaceL23dnorm
 from openretina.modules.layers.scaling import Bias3DLayer
 
 

--- a/openretina/modules/core/base_core.py
+++ b/openretina/modules/core/base_core.py
@@ -9,7 +9,7 @@ from matplotlib import pyplot as plt
 from openretina.modules.layers import FlatLaplaceL23dnorm
 from openretina.modules.layers.convolutions import get_conv_class
 from openretina.modules.layers.reducers import WeightedChannelSumLayer
-from openretina.modules.layers.regularizers import Laplace1d
+from openretina.modules.layers.regularizers import  TimeLaplaceL23dnorm
 from openretina.modules.layers.scaling import Bias3DLayer
 
 
@@ -120,7 +120,7 @@ class SimpleCoreWrapper(Core):
             )
 
         self._input_weights_regularizer_spatial = FlatLaplaceL23dnorm(padding=0)
-        self._input_weights_regularizer_temporal = Laplace1d(padding=0, persistent_buffer=False)
+        self._input_weights_regularizer_temporal = TimeLaplaceL23dnorm(padding=0, persistent_buffer=False)
 
         self.features = torch.nn.Sequential()
         self.color_squashing_layer = (
@@ -180,7 +180,7 @@ class SimpleCoreWrapper(Core):
         assert hasattr(conv_obj, "time_conv")
         time_conv_weight: torch.Tensor = conv_obj.time_conv.weight  # type: ignore
         ch_in, ch_out, t, _, _ = time_conv_weight.shape
-        loss = self._input_weights_regularizer_temporal(time_conv_weight.view(ch_in * ch_out, 1, t), avg=False)
+        loss = self._input_weights_regularizer_temporal(time_conv_weight, avg=False)
         return loss
 
     def temporal_smoothness(self) -> torch.Tensor:

--- a/openretina/modules/layers/regularizers.py
+++ b/openretina/modules/layers/regularizers.py
@@ -116,14 +116,16 @@ class Laplace(nn.Module):
 
 
 class Laplace1d(torch.nn.Module):
+    """
+    Laplace filter for (batched) 1d data.
+    """
     def __init__(self, padding: int | None, persistent_buffer: bool = True):
         super().__init__()
         self.register_buffer("filter", torch.from_numpy(LAPLACE_1D), persistent=persistent_buffer)
         self.padding_size = LAPLACE_1D.shape[-1] // 2 if padding is None else padding
 
-    def forward(self, x: torch.Tensor, avg: bool = False) -> torch.Tensor:
-        agg_fn = torch.mean if avg else torch.sum
-        return agg_fn(F.conv1d(x, self.filter, bias=None, padding=self.padding_size))  # type: ignore
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return F.conv1d(x, self.filter, bias=None, padding=self.padding_size) # type: ignore
 
 
 class TimeLaplaceL23dnorm(nn.Module):
@@ -132,9 +134,9 @@ class TimeLaplaceL23dnorm(nn.Module):
         returns |laplace(filters)| / |filters|
     """
 
-    def __init__(self, padding: int | None = None):
+    def __init__(self, padding: int | None = None, persistent_buffer: bool = True):
         super().__init__()
-        self.laplace = Laplace1d(padding=padding)
+        self.laplace = Laplace1d(padding=padding, persistent_buffer=persistent_buffer)
 
     def forward(self, x: torch.Tensor, avg: bool = False) -> torch.Tensor:
         agg_fn = torch.mean if avg else torch.sum

--- a/openretina/modules/layers/regularizers.py
+++ b/openretina/modules/layers/regularizers.py
@@ -119,13 +119,14 @@ class Laplace1d(torch.nn.Module):
     """
     Laplace filter for (batched) 1d data.
     """
+
     def __init__(self, padding: int | None, persistent_buffer: bool = True):
         super().__init__()
         self.register_buffer("filter", torch.from_numpy(LAPLACE_1D), persistent=persistent_buffer)
         self.padding_size = LAPLACE_1D.shape[-1] // 2 if padding is None else padding
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return F.conv1d(x, self.filter, bias=None, padding=self.padding_size) # type: ignore
+        return F.conv1d(x, self.filter, bias=None, padding=self.padding_size)  # type: ignore
 
 
 class TimeLaplaceL23dnorm(nn.Module):

--- a/tests/models/test_linear_nonlinear.py
+++ b/tests/models/test_linear_nonlinear.py
@@ -1,0 +1,21 @@
+import pytest
+import torch
+
+from openretina.models.linear_nonlinear import SingleCellSeparatedLNP
+
+@pytest.mark.parametrize("smooth_weight_temp",(0.0,1.0,10.0) )
+def test_single_cell_separated_lnp(smooth_weight_temp: float)  -> None:
+    in_shape = (3,10,15,15)  # "channel time height width"
+    torch.manual_seed(0)
+
+    model = SingleCellSeparatedLNP(in_shape, 
+                                   smooth_weight_temp=smooth_weight_temp,)
+    
+    x = torch.rand((1, *in_shape))
+    x = model.crop_input(x)
+    with torch.no_grad():
+        y = model(x)
+    assert y.shape[0] == 1
+    
+
+    

--- a/tests/models/test_linear_nonlinear.py
+++ b/tests/models/test_linear_nonlinear.py
@@ -3,19 +3,19 @@ import torch
 
 from openretina.models.linear_nonlinear import SingleCellSeparatedLNP
 
-@pytest.mark.parametrize("smooth_weight_temp",(0.0,1.0,10.0) )
-def test_single_cell_separated_lnp(smooth_weight_temp: float)  -> None:
-    in_shape = (3,10,15,15)  # "channel time height width"
+
+@pytest.mark.parametrize("smooth_weight_temp", (0.0, 1.0, 10.0))
+def test_single_cell_separated_lnp(smooth_weight_temp: float) -> None:
+    in_shape = (3, 10, 15, 15)  # "channel time height width"
     torch.manual_seed(0)
 
-    model = SingleCellSeparatedLNP(in_shape, 
-                                   smooth_weight_temp=smooth_weight_temp,)
-    
+    model = SingleCellSeparatedLNP(
+        in_shape,
+        smooth_weight_temp=smooth_weight_temp,
+    )
+
     x = torch.rand((1, *in_shape))
     x = model.crop_input(x)
     with torch.no_grad():
         y = model(x)
     assert y.shape[0] == 1
-    
-
-    

--- a/tests/models/test_linear_nonlinear.py
+++ b/tests/models/test_linear_nonlinear.py
@@ -18,4 +18,7 @@ def test_single_cell_separated_lnp(smooth_weight_temp: float) -> None:
     x = model.crop_input(x)
     with torch.no_grad():
         y = model(x)
+        regularization = model.regularizer()
     assert y.shape[0] == 1
+    assert torch.isfinite(regularization)
+    assert regularization >= 0


### PR DESCRIPTION
I think the following is a bug: The `Laplace1d` method convolved the input with a 1d laplace kernel and applied an aggregation function (mean or sum), so its outputs could be negative or positive. In `SimpleCoreWrapper` and `SingleCellSeparatedLNP` however it is used as a regularizer so I think it may not make sense to allow negative values. 

I applied the following changes: 
1. `Laplace1d` is now a filtering class (I removed the aggregation function) just like `Laplace` for 2d inputs. 
2. The regularizer class `TimeLaplaceL23dnorm`. then uses the filtering class  `Laplace1d`  just  like `FlatLaplaceL23dnorm` then use the `Laplace` class, by squaring components and applying some aggregation function. 
3. The places where `Laplace1d` was instantiated in models now instantiate `TimeLaplaceL23dnorm`.
4. When `TimeLaplaceL23dnorm` is called, then the weights of the temporal kernels are no longer reshaped, as this is done in the forward method of `TimeLaplaceL23dnorm` itself. 
5. Added a test of the  `SingleCellSeparatedLNP` and removed a default argument value that raised an error. 

Note that one alternative would be to just take the absolute of the convolution result in the forward method (as done [here in neuralpredictors](https://github.com/open-retina/open-retina/blob/4a54141e234ec5bc6fedee43ff2b57350ae17554/openretina/modules/layers/regularizers.py#L126) but I thought this is cleaner. 