### PR TITLE
WIP: spatial contrast population model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,6 +175,7 @@ random.ipynb
 figures/
 /models
 reports/
+/artifacts/
 model-cache/
 /exp
 openretina_cache_folder/

--- a/README.md
+++ b/README.md
@@ -65,6 +65,22 @@ make test-all
 With this repository we provide already pre-trained retina models that can be used for inference and intepretability out of the box, and dataloaders together with model architectures to train new models.
 For training new models, we rely on [pytorch lightning](https://lightning.ai/docs/pytorch/stable/) in combination with [hydra](https://hydra.cc/docs/intro/) to manage the configurations for training and dataloading.
 
+### Training a model for one neuron
+
+Any core-readout model can be trained from scratch for one neuron by adding the `single` neuron-selection config:
+
+```bash
+uv run openretina train --config-path configs \
+  --config-name sridhar_2025_wn_sc_multicell \
+  +neuron_selection=single \
+  'neuron_selection.session="04"' \
+  'neuron_selection.neuron_ids=[2]'
+```
+
+When the dataset provides stable neuron IDs, `neuron_ids` refers to those IDs rather than positions after quality
+filtering. Otherwise, it refers to zero-based positions in the loaded response array. Hydra multiruns can use the same
+override to launch one independent core-readout model per neuron.
+
 The openretina package is structured as follows:
 
 * modules: pytorch modules that define layers and losses

--- a/configs/hoefling_2024_sc_low_res.yaml
+++ b/configs/hoefling_2024_sc_low_res.yaml
@@ -1,0 +1,61 @@
+# Population Spatial Contrast model on the low-resolution Höfling 2024 data.
+
+defaults:
+  - data_io: hoefling_2024
+  - quality_checks: hoefling_2024
+  - dataloader: hoefling_2024
+  - model: spatial_contrast_core_readout
+  - optimizer: adamw
+  - lr_scheduler: reduce_lr_on_plateau
+  - training_callbacks:
+      - early_stopping
+      - lr_monitor
+      - model_checkpoint
+  - logger:
+      - csv
+  - trainer: default_deterministic
+  - evaluation: default
+  - hydra: default
+  - _self_
+
+exp_name: hoefling_2024_sc_low_res
+seed: 42
+check_stimuli_responses_match: false
+
+model:
+  in_shape: [2, 50, 18, 16]
+  readout:
+    filter_bank_path: ${paths.filter_bank_path}
+    neuron_chunk_size: 64
+  learning_rate: 0.01
+
+dataloader:
+  batch_size: 128
+  train_chunk_size: 50
+
+data_io:
+  retina_pixel_size_um: 50
+
+paths:
+  load_model_path: null
+  cache_dir: ${oc.env:OPENRETINA_CACHE_DIRECTORY}
+  data_dir: ${paths.cache_dir}/data/
+  log_dir: "."
+  output_dir: ${hydra:runtime.output_dir}
+  filter_bank_path: ???
+  movies_path: "https://huggingface.co/datasets/open-retina/open-retina/blob/main/euler_lab/hoefling_2024/stimuli/rgc_natstim_18x16_joint_normalized_2024-01-11.zip"
+  responses_path: "https://huggingface.co/datasets/open-retina/open-retina/resolve/main/euler_lab/hoefling_2024/responses/rgc_natstim_2024-08-14.zip"
+
+matmul_precision:
+  _target_: torch.set_float32_matmul_precision
+  precision: highest
+
+trainer:
+  max_epochs: 30
+  accumulate_grad_batches: 1
+  gradient_clip_val: 1
+
+only_train_readout: false
+
+evaluation:
+  compute_dataset_statistics: false

--- a/configs/model/spatial_contrast_core_readout.yaml
+++ b/configs/model/spatial_contrast_core_readout.yaml
@@ -1,34 +1,37 @@
-# Multi-cell Spatial Contrast core-readout model (Sridhar et al., 2025).
-#
-# Uses a DummyCore (pass-through) with a MultiSpatialContrastReadout.
-# Each neuron has frozen STA-derived spatial and temporal filters and
-# 4 learnable parameters: w (contrast weight) and a, b, c (nonlinearity).
+# Spatial Contrast as a standard configurable core-readout model.
 
-_target_: openretina.models.spatial_contrast.SpatialContrastCoreReadout
-_convert_: all
+hidden_channels: null
+in_shape: ???
+n_neurons_dict: ??? # Set dynamically from the loaded sessions.
 
-# --- Required: set in the outer config ---
-in_shape: ???          # (channels, time, height, width) of the stimulus
-n_neurons_dict: ???    # Set dynamically at runtime via data_info
-sta_dir: ???           # Directory containing STA .npy files
-flip_sta: ???          # Whether the STA needs horizontal flipping (dataset-dependent)
+core:
+  _target_: openretina.modules.core.base_core.DummyCore
+  _convert_: object
+  cut_first_n_frames: 0
 
-# --- STA file naming pattern ---
-sta_file_pattern: "cell_data_{retina_index}_WN_stas_cell_{cell_index}.npy"
+readout:
+  _target_: openretina.modules.readout.spatial_contrast_model_readout.MultiSpatialContrastReadout
+  _convert_: all
+  data_info: null # UnifiedCoreReadout injects runtime session metadata.
+  filter_bank_path: null
+  sta_dir: null
+  sta_file_pattern: "cell_data_{retina_index}_WN_stas_cell_{cell_index}.npy"
+  flip_sta: false
+  temporal_crop_frames: 30
+  sigma_contour: 3.0
+  w_init: 0.0
+  a_init: 4.0
+  b_init: 1.0
+  c_init: -5.0
+  neuron_chunk_size: 32
+  learnable_filters: false
+  temporal_smoothness_reg: 0.0
+  spatial_center_reg: 0.0
+  spatial_scale_reg: 0.0
 
-# --- Spatial/temporal filter settings ---
-temporal_crop_frames: 30    # Keep this many of the most recent STA frames
-sigma_contour: 3.0          # Gaussian RF is masked to this many standard deviations
-cut_first_n_frames: 0       # Frames cut by DummyCore (0 = no cutting)
-
-# --- Learnable parameter initial values ---
-w_init: 0.0     # Spatial contrast weight (0 = start as a pure LN model)
-a_init: 4.0     # Output scaling
-b_init: 1.0     # Input gain
-c_init: -5.0    # Offset (negative = low baseline firing rate)
-
-# --- Memory / performance ---
-neuron_chunk_size: 32   # Max neurons per forward-pass chunk (increase on larger GPUs)
-
-# --- Training ---
 learning_rate: 0.01
+loss:
+  _target_: openretina.modules.losses.PoissonLoss3d
+  avg: true
+optimizer: ${optimizer}
+lr_scheduler: ${lr_scheduler}

--- a/configs/neuron_selection/single.yaml
+++ b/configs/neuron_selection/single.yaml
@@ -1,0 +1,3 @@
+# Train a fresh model for selected stable neuron IDs from one session.
+session: ???
+neuron_ids: ???

--- a/configs/sridhar_2025_nm_sc_multicell.yaml
+++ b/configs/sridhar_2025_nm_sc_multicell.yaml
@@ -35,6 +35,10 @@ dataloader:
 data_io:
   sessions:
     - ${dataloader.retina_index}
+  stimuli:
+    sessions: ${data_io.sessions}
+  responses:
+    sessions: ${data_io.sessions}
 
 model:
   in_shape:
@@ -42,8 +46,9 @@ model:
     - ${dataloader.num_of_frames}
     - ${data_io.stimulus_height}
     - ${data_io.stimulus_width}
-  sta_dir: "${paths.data_dir}/stas"
-  flip_sta: ${data_io.flip_sta}
+  readout:
+    sta_dir: "${paths.data_dir}/stas"
+    flip_sta: ${data_io.flip_sta}
 
 paths:
   load_model_path: null

--- a/configs/sridhar_2025_wn_sc_multicell.yaml
+++ b/configs/sridhar_2025_wn_sc_multicell.yaml
@@ -35,6 +35,10 @@ dataloader:
 data_io:
   sessions:
     - ${dataloader.retina_index}
+  stimuli:
+    sessions: ${data_io.sessions}
+  responses:
+    sessions: ${data_io.sessions}
 
 model:
   in_shape:
@@ -42,8 +46,9 @@ model:
     - ${dataloader.num_of_frames}
     - ${data_io.stimulus_height}
     - ${data_io.stimulus_width}
-  sta_dir: "${paths.data_dir}/stas"
-  flip_sta: ${data_io.flip_sta}
+  readout:
+    sta_dir: "${paths.data_dir}/stas"
+    flip_sta: ${data_io.flip_sta}
 
 paths:
   load_model_path: null

--- a/openretina/cli/train.py
+++ b/openretina/cli/train.py
@@ -9,7 +9,7 @@ import torch
 import torch.utils.data as data
 from omegaconf import DictConfig, OmegaConf
 
-from openretina.data_io.base import compute_data_info
+from openretina.data_io.base import compute_data_info, select_neurons
 from openretina.data_io.cyclers import LongCycler, ShortCycler
 from openretina.models.core_readout import UnifiedCoreReadout, load_core_readout_model
 from openretina.utils.log_to_mlflow import log_to_mlflow
@@ -48,6 +48,13 @@ def train_model(cfg: DictConfig) -> float | None:
     movies_dict = hydra.utils.call(cfg.data_io.stimuli)
     neuron_data_dict = hydra.utils.call(cfg.data_io.responses)
 
+    neuron_selection = cfg.get("neuron_selection")
+    if neuron_selection is not None:
+        session = neuron_selection.session
+        neuron_data_dict = select_neurons(neuron_data_dict, session, neuron_selection.neuron_ids)
+        if isinstance(movies_dict, dict):
+            movies_dict = {session: movies_dict[session]}
+
     if cfg.check_stimuli_responses_match:
         for session, neuron_data in neuron_data_dict.items():
             neuron_data.check_matching_stimulus(movies_dict[session])
@@ -73,6 +80,8 @@ def train_model(cfg: DictConfig) -> float | None:
 
     ### Model init
     load_model_path = cfg.paths.get("load_model_path")
+    if neuron_selection is not None and load_model_path:
+        raise ValueError("Neuron selection trains a fresh model and cannot be combined with paths.load_model_path")
     if load_model_path:
         log.info(f"Loading model from <{load_model_path}>")
         device = "cuda" if torch.cuda.is_available() else "cpu"

--- a/openretina/data_io/base.py
+++ b/openretina/data_io/base.py
@@ -3,7 +3,7 @@ import pickle
 import warnings
 from dataclasses import InitVar, dataclass, field
 from functools import cached_property
-from typing import Any, Optional
+from typing import Any, Iterable, Optional
 
 import numpy as np
 import torch
@@ -103,6 +103,7 @@ class ResponsesTrainTestSplit:
     test_by_trial_dict: dict = field(default_factory=lambda: {})
     stim_id: str | None = None
     session_kwargs: dict[str, Any] = field(default_factory=lambda: {})
+    neuron_ids: np.ndarray | None = None
 
     def __post_init__(self, test):
         if (len(self.test_dict) == 0) == (test is None):
@@ -128,6 +129,14 @@ class ResponsesTrainTestSplit:
         assert self.train.shape[0] == self.test_neurons, (
             "Train and test responses should have the same number of neurons."
         )
+        if self.neuron_ids is None:
+            self.neuron_ids = np.arange(self.train.shape[0])
+        else:
+            self.neuron_ids = np.asarray(self.neuron_ids)
+            if self.neuron_ids.ndim != 1 or len(self.neuron_ids) != self.train.shape[0]:
+                raise ValueError("neuron_ids must contain one ID per neuron")
+            if len(set(self.neuron_ids.tolist())) != len(self.neuron_ids):
+                raise ValueError("neuron_ids must be unique")
         if self.train.shape[0] > self.train.shape[1]:
             warnings.warn(
                 "The number of neurons is greater than the number of timebins in the train responses. "
@@ -185,6 +194,54 @@ class ResponsesTrainTestSplit:
         if not self.test_by_trial_dict:
             return None
         return self.test_by_trial_dict.get(name)
+
+    def select_neurons(self, neuron_ids: Iterable[Any]) -> "ResponsesTrainTestSplit":
+        """Return a copy containing the requested stable neuron IDs."""
+        requested_ids = list(neuron_ids)
+        if not requested_ids:
+            raise ValueError("At least one neuron ID must be selected")
+
+        assert self.neuron_ids is not None
+        positions = []
+        for neuron_id in requested_ids:
+            matches = np.flatnonzero(self.neuron_ids == neuron_id)
+            if len(matches) != 1:
+                raise KeyError(f"Unknown neuron ID {neuron_id!r}; available IDs: {self.neuron_ids.tolist()}")
+            positions.append(int(matches[0]))
+        if len(set(positions)) != len(positions):
+            raise ValueError("Neuron IDs must not be repeated")
+
+        n_neurons = self.n_neurons
+
+        def select_metadata(value):
+            if isinstance(value, np.ndarray) and value.ndim > 0 and value.shape[0] == n_neurons:
+                return value[positions]
+            if isinstance(value, torch.Tensor) and value.ndim > 0 and value.shape[0] == n_neurons:
+                return value[positions]
+            if isinstance(value, (list, tuple)) and len(value) == n_neurons:
+                selected = [value[position] for position in positions]
+                return type(value)(selected)
+            return value
+
+        return ResponsesTrainTestSplit(
+            train=self.train[positions],
+            test_dict={name: responses[positions] for name, responses in self.test_dict.items()},
+            test_by_trial_dict={name: responses[:, positions] for name, responses in self.test_by_trial_dict.items()},
+            stim_id=self.stim_id,
+            session_kwargs={key: select_metadata(value) for key, value in self.session_kwargs.items()},
+            neuron_ids=self.neuron_ids[positions],
+        )
+
+
+def select_neurons(
+    responses_dictionary: dict[str, ResponsesTrainTestSplit],
+    session: str,
+    neuron_ids: Iterable[Any],
+) -> dict[str, ResponsesTrainTestSplit]:
+    """Select neurons from one session for an independent model training run."""
+    if session not in responses_dictionary:
+        raise KeyError(f"Unknown session {session!r}; available sessions: {sorted(responses_dictionary)}")
+    return {session: responses_dictionary[session].select_neurons(neuron_ids)}
 
 
 def get_n_neurons_per_session(responses_dict: dict[str, ResponsesTrainTestSplit]) -> dict[str, int]:
@@ -334,6 +391,7 @@ def compute_data_info(
 
     return {
         "n_neurons_dict": n_neurons_dict,
+        "neuron_ids_dict": {name: responses.neuron_ids for name, responses in neuron_data_dictionary.items()},
         "mean_activity_dict": mean_activity_dict,
         "input_shape": input_shape,
         "sessions_kwargs": sessions_kwargs,

--- a/openretina/data_io/hoefling_2024/responses.py
+++ b/openretina/data_io/hoefling_2024/responses.py
@@ -428,6 +428,7 @@ def make_final_responses(
             test=test_responses,
             test_by_trial=test_responses_by_trial,
             stim_id=response_type,
+            neuron_ids=upsampled_data_dict[field]["roi_ids"],
             session_kwargs={
                 "eye": upsampled_data_dict[field]["eye"],
                 "scan_sequence_idx": upsampled_data_dict[field]["scan_sequence_idx"],

--- a/openretina/data_io/hoefling_2024/spatial_contrast.py
+++ b/openretina/data_io/hoefling_2024/spatial_contrast.py
@@ -1,0 +1,115 @@
+"""Natural-movie filter initialization for the SC model on Höfling 2024 data."""
+
+from pathlib import Path
+
+import numpy as np
+import torch
+
+from openretina.data_io.base import MoviesTrainTestSplit, ResponsesTrainTestSplit
+from openretina.data_io.hoefling_2024.constants import CLIP_LENGTH, NUM_CLIPS
+
+_MISLABELED_LEFT_SESSION = "session_2_ventral2_20200626"
+
+
+def _roi_centers(roi_mask: np.ndarray, roi_ids: np.ndarray, height: int, width: int) -> tuple[np.ndarray, np.ndarray]:
+    """Map recording ROI centers to the normalized readout grid used by Höfling loaders."""
+    centers = []
+    for roi_id in roi_ids:
+        y, x = np.nonzero(roi_mask == -roi_id)
+        if not len(y):
+            raise ValueError(f"ROI {roi_id} is absent from its ROI mask")
+        centers.append((((y.mean() / 25 + 2.75) / 8) * 2 - 1, ((x.mean() / 25 + 2.75) / 8) * 2 - 1))
+    normalized = np.asarray(centers, dtype=np.float32)
+    pixel_y = np.clip(np.rint((normalized[:, 0] + 1) * (height - 1) / 2), 0, height - 1).astype(int)
+    pixel_x = np.clip(np.rint((normalized[:, 1] + 1) * (width - 1) / 2), 0, width - 1).astype(int)
+    return pixel_y, pixel_x
+
+
+def _gaussian_filters(
+    center_y: np.ndarray,
+    center_x: np.ndarray,
+    height: int,
+    width: int,
+    sigma: float,
+) -> torch.Tensor:
+    grid_y, grid_x = np.mgrid[:height, :width]
+    distance_sq = (grid_y - center_y[:, None, None]) ** 2 + (grid_x - center_x[:, None, None]) ** 2
+    filters = np.exp(-distance_sq / (2 * sigma**2)).astype(np.float32)
+    filters[distance_sq > (3 * sigma) ** 2] = 0
+    filters /= filters.sum(axis=(1, 2), keepdims=True)
+    return torch.from_numpy(filters)
+
+
+def estimate_filter_bank(
+    movies: MoviesTrainTestSplit,
+    responses: dict[str, ResponsesTrainTestSplit],
+    validation_clip_indices: list[int],
+    output_path: str | Path,
+    temporal_filter_length: int = 30,
+    spatial_sigma: float = 1.5,
+) -> Path:
+    """Estimate ROI-centered spatial and reverse-correlation temporal filters.
+
+    Temporal filters use only non-validation training clips. The temporal course
+    is sampled at each ROI center, matching how the original SC model extracts
+    the temporal component at the receptive-field center.
+    """
+    if movies.random_sequences is None:
+        raise ValueError("Höfling random presentation sequences are required")
+    channels, _, height, width = movies.train.shape
+    movie_clips = movies.train.reshape(channels, NUM_CLIPS, CLIP_LENGTH, height, width)
+    is_validation = np.isin(movies.random_sequences, validation_clip_indices)
+
+    spatial_filters_dict: dict[str, torch.Tensor] = {}
+    temporal_filters_dict: dict[str, torch.Tensor] = {}
+    neuron_ids_dict: dict[str, list[int]] = {}
+
+    for session, response in responses.items():
+        kwargs = response.session_kwargs
+        sequence_index = int(np.asarray(kwargs["scan_sequence_idx"]).item())
+        presentation_order = movies.random_sequences[:, sequence_index].astype(int)
+        keep = ~is_validation[:, sequence_index]
+        stimulus = movie_clips[:, presentation_order[keep]].reshape(channels, -1, height, width)
+        if kwargs["eye"] == "left" and session != _MISLABELED_LEFT_SESSION:
+            stimulus = stimulus[..., ::-1].copy()  # type: ignore[assignment]
+
+        center_y, center_x = _roi_centers(np.asarray(kwargs["roi_mask"]), np.asarray(kwargs["roi_ids"]), height, width)
+        spatial_filters_dict[session] = _gaussian_filters(center_y, center_x, height, width, spatial_sigma)
+        assert response.neuron_ids is not None
+        neuron_ids_dict[session] = response.neuron_ids.tolist()
+
+        local_stimulus = stimulus[:, :, center_y, center_x].transpose(2, 0, 1).astype(np.float32)
+        local_stimulus -= local_stimulus.mean(axis=2, keepdims=True)
+        response_train = response.train.reshape(response.n_neurons, NUM_CLIPS, CLIP_LENGTH)[:, keep].reshape(
+            response.n_neurons, -1
+        )
+        response_train = response_train.astype(np.float32)
+        response_train -= response_train.mean(axis=1, keepdims=True)
+
+        stimulus_windows = torch.from_numpy(local_stimulus).unfold(2, temporal_filter_length, 1)
+        aligned_response = torch.from_numpy(response_train[:, temporal_filter_length - 1 :])
+        temporal_filters = torch.einsum("nctl,nt->ncl", stimulus_windows, aligned_response)
+        temporal_filters /= aligned_response.shape[1]
+        norms = temporal_filters.square().sum(dim=(1, 2), keepdim=True).sqrt()
+        degenerate = norms.flatten() < 1e-8
+        temporal_filters /= norms.clamp_min(1e-8)
+        temporal_filters[degenerate, :, -1] = 1 / channels**0.5
+        temporal_filters_dict[session] = temporal_filters
+
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    torch.save(
+        {
+            "spatial_filters_dict": spatial_filters_dict,
+            "temporal_filters_dict": temporal_filters_dict,
+            "neuron_ids_dict": neuron_ids_dict,
+            "metadata": {
+                "method": "roi_center_reverse_correlation",
+                "validation_clip_indices": validation_clip_indices,
+                "temporal_filter_length": temporal_filter_length,
+                "spatial_sigma": spatial_sigma,
+            },
+        },
+        output_path,
+    )
+    return output_path

--- a/openretina/data_io/sridhar_2025/dataloaders.py
+++ b/openretina/data_io/sridhar_2025/dataloaders.py
@@ -7,6 +7,7 @@ import numpy as np
 import torch
 from torch.utils.data import DataLoader, Dataset
 
+from openretina.data_io.base import ResponsesTrainTestSplit
 from openretina.data_io.sridhar_2025.constants import TEST_DATA_FRAMES
 from openretina.data_io.sridhar_2025.dataloader_utils import (
     ChunkedSampler,
@@ -19,6 +20,26 @@ from openretina.data_io.sridhar_2025.stimuli import load_frames, process_fixatio
 from openretina.utils.file_utils import get_local_file_path
 
 default_image_datapoint = namedtuple("default_image_datapoint", ["inputs", "targets"])
+
+
+def _responses_from_splits(
+    neuron_data_dictionary: dict[str, ResponsesTrainTestSplit] | None,
+) -> dict[str, dict[str, Any]] | None:
+    if not neuron_data_dictionary:
+        return None
+
+    responses = {}
+    for session_id, split in neuron_data_dictionary.items():
+        frames_per_trial = split.session_kwargs["frames_per_trial"]
+        num_trials = split.session_kwargs["num_trials"]
+        test_by_trial = split.get_test_by_trial()
+        responses[session_id] = {
+            "train_responses": split.train.reshape(split.n_neurons, frames_per_trial, num_trials),
+            "test_responses": split.test_response,
+            "test_responses_by_trial": None if test_by_trial is None else np.transpose(test_by_trial, (1, 2, 0)),
+            "cell_indices": split.neuron_ids.tolist() if split.neuron_ids is not None else None,
+        }
+    return responses
 
 
 def crop_based_on_fixation(img, x_center, y_center, img_h, img_w, flip=False, padding=200):
@@ -493,6 +514,7 @@ def frame_movie_loader(
     shuffle=None,
     sta_dir="stas",
     get_locations: bool = True,
+    neuron_data_dictionary: dict[str, ResponsesTrainTestSplit] | None = None,
     **kwargs,
 ):
     """
@@ -624,6 +646,7 @@ def frame_movie_loader(
     basepath = get_local_file_path(str(basepath))
 
     dataloaders: dict[str, dict] = {"train": {}, "validation": {}, "test": {}}
+    retina_indices: list[Any]
     if retina_index is None:
         retina_indices = list(fixation_files.keys())
     else:
@@ -633,9 +656,11 @@ def frame_movie_loader(
         fixation_file = file.readlines()
         fixations = process_fixations(fixation_file, flip_imgs=flip_imgs)
 
-    responses = load_responses(
+    responses = _responses_from_splits(neuron_data_dictionary) or load_responses(
         basepath, files=files, stimulus_seed=stimulus_seed, excluded_cells=excluded_cells, cell_index=cell_index
     )
+    if len(responses) == 1:
+        retina_indices = list(responses)
     frames = load_frames(
         img_dir_name=os.path.join(basepath, img_dir_name),
         frame_file=frame_file,
@@ -679,7 +704,10 @@ def frame_movie_loader(
         locations = None
         if get_locations:
             assert sta_dir is not None
-            if cell_index is not None:
+            selected_cell_indices = responses[retina_index].get("cell_indices")
+            if selected_cell_indices is not None:
+                cells = selected_cell_indices
+            elif cell_index is not None:
                 cells = [cell_index]
             else:
                 excluded = excluded_cells[retina_index] if excluded_cells is not None else {}
@@ -1114,15 +1142,21 @@ def white_noise_loader(
     chunked_sampling=True,
     get_locations=True,
     sta_dir="stas",
+    neuron_data_dictionary: dict[str, ResponsesTrainTestSplit] | None = None,
     **kwargs,
 ):
     basepath = get_local_file_path(str(basepath))
-    dataloaders = {"train": {}, "validation": {}, "test": {}}
+    dataloaders: dict[str, dict] = {"train": {}, "validation": {}, "test": {}}
+    retina_indices: list[Any]
     if retina_index is None:
         retina_indices = list(files.keys())
     else:
         retina_indices = [retina_index]
-    responses = load_responses(basepath, files=files, excluded_cells=excluded_cells, cell_index=cell_index)
+    responses = _responses_from_splits(neuron_data_dictionary) or load_responses(
+        basepath, files=files, excluded_cells=excluded_cells, cell_index=cell_index
+    )
+    if len(responses) == 1:
+        retina_indices = list(responses)
 
     for retina_index in retina_indices:
         train_responses = responses[retina_index]["train_responses"]
@@ -1151,10 +1185,13 @@ def white_noise_loader(
 
         if get_locations:
             assert sta_dir is not None
+            selected_cell_indices = responses[retina_index].get("cell_indices")
             locations = get_locations_from_stas(
                 sta_dir=os.path.join(basepath, sta_dir),
                 retina_index=retina_index,
-                cells=[cell_index]
+                cells=selected_cell_indices
+                if selected_cell_indices is not None
+                else [cell_index]
                 if cell_index is not None
                 else [
                     x

--- a/openretina/data_io/sridhar_2025/responses.py
+++ b/openretina/data_io/sridhar_2025/responses.py
@@ -1,6 +1,6 @@
 import os
 import pickle
-from typing import Any, Optional
+from typing import Any, Iterable, Optional
 
 import numpy as np
 
@@ -19,9 +19,13 @@ def load_responses(
     stimulus_seed: int = 0,
     excluded_cells: Optional[dict[Any, list[int]]] = None,
     cell_index: Optional[int] = None,
+    sessions: Iterable[str] | None = None,
 ) -> dict[str, dict[str, Any]]:
     base_path = get_local_file_path(str(base_path))
     responses = {}
+
+    if sessions is not None:
+        files = {session: files[session] for session in sessions}
 
     for session_id, file in files.items():
         with open(os.path.join(base_path, file), "rb") as pkl:
@@ -79,6 +83,7 @@ def response_splits_from_pickles(
     stimulus_seed: int = 0,
     excluded_cells: Optional[dict[Any, list[int]]] = None,
     cell_index: Optional[int] = None,
+    sessions: Iterable[str] | None = None,
 ) -> dict[str, ResponsesTrainTestSplit]:
     """
     Convert Sridhar pickled responses into ``ResponsesTrainTestSplit`` objects compatible with the unified pipeline.
@@ -90,6 +95,7 @@ def response_splits_from_pickles(
         stimulus_seed=stimulus_seed,
         excluded_cells=excluded_cells,
         cell_index=cell_index,
+        sessions=sessions,
     )
 
     splits: dict[str, ResponsesTrainTestSplit] = {}
@@ -114,6 +120,7 @@ def response_splits_from_pickles(
             test=test_responses,
             test_by_trial=test_by_trial_formatted,
             stim_id=f"sridhar_{session_id}",
+            neuron_ids=np.asarray(cell_indices),
             session_kwargs={
                 "stimulus_seed": stimulus_seed,
                 "frames_per_trial": frames_per_trial,

--- a/openretina/data_io/sridhar_2025/stimuli.py
+++ b/openretina/data_io/sridhar_2025/stimuli.py
@@ -1,5 +1,6 @@
 import os
 import pickle
+from typing import Iterable
 
 import numpy as np
 from jaxtyping import Float
@@ -103,6 +104,7 @@ def build_movies_from_responses(
     stimulus_seed: int = 0,
     norm_mean: float = 0.0,
     norm_std: float = 1.0,
+    sessions: Iterable[str] | None = None,
 ) -> dict[str, MoviesTrainTestSplit]:
     """
     Create MoviesTrainTestSplit placeholders with accurate frame counts by reading response files.
@@ -124,6 +126,7 @@ def build_movies_from_responses(
         stimulus_seed: Random seed used for trial selection (affects frame counts for some sessions).
         norm_mean: Normalization mean for the stimulus.
         norm_std: Normalization std for the stimulus.
+        sessions: Optional subset of response-file session IDs to load.
 
     Returns:
         Dictionary mapping session IDs to MoviesTrainTestSplit placeholders with accurate frame counts.
@@ -131,6 +134,9 @@ def build_movies_from_responses(
 
     base_path = get_local_file_path(str(base_path))
     movies = {}
+
+    if sessions is not None:
+        response_files = {session: response_files[session] for session in sessions}
 
     for session_id, response_file in response_files.items():
         with open(os.path.join(base_path, response_file), "rb") as f:

--- a/openretina/models/core_readout.py
+++ b/openretina/models/core_readout.py
@@ -106,7 +106,6 @@ class BaseCoreReadout(LightningModule):
 
     def training_step(self, batch: tuple[str, DataPoint], batch_idx: int) -> torch.Tensor:
         session_id, data_point = batch
-        breakpoint()
         model_output = self.forward(data_point.inputs, session_id)
         loss = self.loss.forward(model_output, data_point.targets)
         regularization_loss_core = self.core.regularizer()

--- a/openretina/models/core_readout.py
+++ b/openretina/models/core_readout.py
@@ -10,7 +10,7 @@ import torch.nn as nn
 from jaxtyping import Float, Int
 from lightning import LightningModule
 from lightning.pytorch.utilities import grad_norm
-from omegaconf import DictConfig
+from omegaconf import DictConfig, OmegaConf, open_dict
 
 from openretina.data_io.base_dataloader import DataPoint
 from openretina.modules.core.base_core import Core, SimpleCoreWrapper
@@ -106,6 +106,7 @@ class BaseCoreReadout(LightningModule):
 
     def training_step(self, batch: tuple[str, DataPoint], batch_idx: int) -> torch.Tensor:
         session_id, data_point = batch
+        breakpoint()
         model_output = self.forward(data_point.inputs, session_id)
         loss = self.loss.forward(model_output, data_point.targets)
         regularization_loss_core = self.core.regularizer()
@@ -340,17 +341,22 @@ class UnifiedCoreReadout(BaseCoreReadout):
         )
 
         # determine input_shape of readout if it is not already present
-        if "in_shape" not in readout:
+        if "in_shape" not in readout or OmegaConf.is_missing(readout, "in_shape") or readout.in_shape is None:
             in_shape_readout = self.compute_readout_input_shape(in_shape, core_module)
-            readout["in_shape"] = (in_shape_readout[0],) + tuple(in_shape_readout[1:])
+            with open_dict(readout):
+                readout["in_shape"] = (in_shape_readout[0],) + tuple(in_shape_readout[1:])
 
         # Extract mean_activity_dict from data_info if available
         mean_activity_dict = None if data_info is None else data_info.get("mean_activity_dict")
 
+        readout_kwargs = {}
+        if "data_info" in readout:
+            readout_kwargs["data_info"] = data_info
         readout_module = hydra.utils.instantiate(
             readout,
             n_neurons_dict=n_neurons_dict,
             mean_activity_dict=mean_activity_dict,
+            **readout_kwargs,
         )
 
         if loss is not None and isinstance(loss, DictConfig):

--- a/openretina/models/spatial_contrast.py
+++ b/openretina/models/spatial_contrast.py
@@ -5,16 +5,14 @@ Extends the Linear-Nonlinear (LN) model by adding a local spatial contrast term.
 The spatial and temporal filters are frozen from pre-computed STAs; only 4 parameters
 per neuron are learned: the contrast weight (w) and three nonlinearity parameters (a, b, c).
 
-Provides two variants:
-- SingleCellSpatialContrast: standalone LightningModule for one neuron at a time
-- SpatialContrastCoreReadout: multi-cell core-readout model using DummyCore + MultiSpatialContrastReadout
+The population variant uses ``UnifiedCoreReadout`` with a pass-through core and
+``MultiSpatialContrastReadout`` configured as its readout.
 
 Reference: Sridhar S, Vystrčilová M, Khani MH, Karamanlis D, Schreyer HM, Ramakrishna V,
 Krüppel S, Zapp SJ, Mietsch M, Ecker AS, Gollisch T (2025): Modeling spatial contrast
 sensitivity in responses of primate retinal ganglion cells to natural movies.
 """
 
-import logging
 from pathlib import Path
 from typing import Any, Callable, Optional, Union
 
@@ -28,17 +26,9 @@ from lightning.pytorch.core.optimizer import LightningOptimizer
 from torch.optim import Optimizer
 
 from openretina.data_io.base_dataloader import DataPoint
-from openretina.models.core_readout import BaseCoreReadout
-from openretina.modules.core.base_core import DummyCore
 from openretina.modules.losses import CorrelationLoss3d, PoissonLoss3d
-from openretina.modules.readout.spatial_contrast_model_readout import (
-    MultiSpatialContrastReadout,
-    SpatialContrastReadout,
-)
 from openretina.utils.file_utils import get_local_file_path
 from openretina.utils.sta_processing import load_sta_and_extract_filters
-
-LOGGER = logging.getLogger(__name__)
 
 
 class SingleCellSpatialContrast(LightningModule):
@@ -296,8 +286,10 @@ class SingleCellSpatialContrast(LightningModule):
         """Override implementation to allow parameter clamping at each training step"""
         optimizer.step(closure=optimizer_closure)
 
-        # To avoid negative model predictions, clamp the gain parameter in the nonlinearity
-        self.w.data.clamp_(min=0.0)
+        # Keep the contrast weight and output scale nonnegative.
+        with torch.no_grad():
+            self.w.clamp_(min=0.0)
+            self.nl_a.clamp_(min=0.0)
 
     def configure_optimizers(self):
         optimizer = torch.optim.AdamW(self.parameters(), lr=self.learning_rate)
@@ -322,148 +314,3 @@ class SingleCellSpatialContrast(LightningModule):
                 "frequency": 1,
             },
         }
-
-
-class SpatialContrastCoreReadout(BaseCoreReadout):
-    """Multi-cell Spatial Contrast model following the core-readout pattern.
-
-    Uses a DummyCore (pass-through) paired with a MultiSpatialContrastReadout
-    that handles N neurons per session. Frozen STA-derived spatial and temporal
-    filters are loaded at construction time; only 4 parameters per neuron
-    (w, a, b, c) are learned.
-
-    Designed for Hydra config instantiation. The STA file pattern uses
-    ``{retina_index}`` and ``{cell_index}`` placeholders that are filled
-    from ``data_info["sessions_kwargs"]``.
-
-    Args:
-        in_shape: (channels, time, height, width) of input stimulus.
-        n_neurons_dict: Session key -> number of neurons.
-        sta_dir: Directory containing STA .npy files.
-        sta_file_pattern: Filename pattern with {retina_index} and {cell_index}
-            placeholders, e.g. "cell_data_{retina_index}_WN_stas_cell_{cell_index}.npy".
-        flip_sta: Whether to flip STAs horizontally.
-        temporal_crop_frames: Number of most-recent STA frames to keep.
-        sigma_contour: Spatial filter mask contour in sigmas.
-        cut_first_n_frames: Frames cut by DummyCore (temporal alignment).
-        w_init, a_init, b_init, c_init: Initial per-neuron parameter values.
-        learning_rate: Learning rate for AdamW.
-        neuron_chunk_size: Max neurons processed at once in the readout forward
-            pass. Controls the GPU memory/speed trade-off. Default 32 works
-            on 8 GB GPUs.
-        loss: Training loss module.
-        evaluation_loss: Evaluation metric module.
-        data_info: Data metadata dict (must contain sessions_kwargs with cell_indices).
-    """
-
-    def __init__(
-        self,
-        in_shape: Int[tuple, "channels time height width"],
-        n_neurons_dict: dict[str, int],
-        sta_dir: Union[Path, str],
-        sta_file_pattern: str = "cell_data_{retina_index}_WN_stas_cell_{cell_index}.npy",
-        flip_sta: bool = False,
-        temporal_crop_frames: int | None = 30,
-        sigma_contour: float = 3.0,
-        cut_first_n_frames: int = 0,
-        w_init: float = 0.0,
-        a_init: float = 4.0,
-        b_init: float = 1.0,
-        c_init: float = -5.0,
-        learning_rate: float = 0.01,
-        neuron_chunk_size: int = 32,
-        loss: nn.Module | None = None,
-        evaluation_loss: nn.Module | None = None,
-        data_info: dict[str, Any] | None = None,
-    ):
-        in_shape = tuple(in_shape)
-        target_spatial_shape = (in_shape[-2], in_shape[-1])
-
-        local_sta_dir = get_local_file_path(Path(sta_dir).as_posix())
-
-        # Extract cell indices from data_info
-        if data_info is None:
-            raise ValueError("data_info is required for SpatialContrastCoreReadout")
-        sessions_kwargs = data_info.get("sessions_kwargs", {})
-
-        spatial_filters_dict: dict[str, torch.Tensor] = {}
-        temporal_filters_dict: dict[str, torch.Tensor] = {}
-
-        for session_key, n_neurons in n_neurons_dict.items():
-            session_kw = sessions_kwargs.get(session_key, {})
-            cell_indices = session_kw.get("cell_indices")
-            if cell_indices is None:
-                raise ValueError(
-                    f"cell_indices not found in data_info['sessions_kwargs']['{session_key}']. "
-                    "Ensure the dataloader provides cell_indices in session_kwargs."
-                )
-
-            spatial_list = []
-            temporal_list = []
-            for cell_idx in cell_indices:
-                file_name = sta_file_pattern.format(retina_index=session_key, cell_index=cell_idx)
-                spatial_filter, temporal_filter, _ = load_sta_and_extract_filters(
-                    sta_dir=local_sta_dir,
-                    file_name=file_name,
-                    flip_sta=flip_sta,
-                    target_spatial_shape=target_spatial_shape,
-                    temporal_crop_frames=temporal_crop_frames,
-                    sigma_contour=sigma_contour,
-                )
-                spatial_list.append(torch.from_numpy(spatial_filter))
-                temporal_list.append(torch.from_numpy(temporal_filter))
-
-            spatial_filters_dict[session_key] = torch.stack(spatial_list)
-            temporal_filters_dict[session_key] = torch.stack(temporal_list)
-
-            LOGGER.info(
-                f"Session {session_key}: loaded {len(cell_indices)} STA filters "
-                f"(spatial: {spatial_filters_dict[session_key].shape}, "
-                f"temporal: {temporal_filters_dict[session_key].shape})"
-            )
-
-        core = DummyCore(cut_first_n_frames=cut_first_n_frames)
-
-        mean_activity_dict = data_info.get("mean_activity_dict")
-
-        readout = MultiSpatialContrastReadout(
-            in_shape=in_shape,
-            n_neurons_dict=n_neurons_dict,
-            spatial_filters_dict=spatial_filters_dict,
-            temporal_filters_dict=temporal_filters_dict,
-            w_init=w_init,
-            a_init=a_init,
-            b_init=b_init,
-            c_init=c_init,
-            mean_activity_dict=mean_activity_dict,
-            neuron_chunk_size=neuron_chunk_size,
-        )
-
-        # Default to avg=True Poisson loss to match the single-cell SC model.
-        # The BaseCoreReadout default (avg=False → loss.sum()) produces gradient
-        # magnitudes that scale with neuron count, causing NaN for large sessions.
-        if loss is None:
-            loss = PoissonLoss3d(avg=True)
-
-        super().__init__(
-            core=core,
-            readout=readout,
-            learning_rate=learning_rate,
-            loss=loss,
-            evaluation_loss=evaluation_loss,
-            data_info=data_info,
-        )
-
-    def optimizer_step(
-        self,
-        epoch: int,
-        batch_idx: int,
-        optimizer: Optimizer | LightningOptimizer,
-        optimizer_closure: Callable[[], Any] | None = None,
-    ) -> None:
-        """Clamp nl_a >= 0 after each step to avoid negative predictions."""
-        optimizer.step(closure=optimizer_closure)
-
-        for readout in self.readout.values():
-            assert isinstance(readout, SpatialContrastReadout)
-            readout.nl_a.data.clamp_(min=0.0)

--- a/openretina/modules/readout/spatial_contrast_model_readout.py
+++ b/openretina/modules/readout/spatial_contrast_model_readout.py
@@ -1,14 +1,15 @@
 """
 Multi-neuron Spatial Contrast readout following the core-readout pattern.
 
-SpatialContrastReadout handles N neurons in a single session with frozen
-spatial/temporal filters and per-neuron learnable parameters (w, a, b, c).
+SpatialContrastReadout handles N neurons in a single session with fixed or
+learnable spatial/temporal filters and per-neuron parameters (w, a, b, c).
 
 MultiSpatialContrastReadout wraps multiple sessions, each with its own
 SpatialContrastReadout, following the MultiReadoutBase interface.
 """
 
-from typing import Literal
+from pathlib import Path
+from typing import Any, Literal
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -20,14 +21,32 @@ from jaxtyping import Float, Int
 
 from openretina.modules.readout.base import Readout
 from openretina.modules.readout.multi_readout import MultiReadoutBase
+from openretina.utils.file_utils import get_local_file_path
+from openretina.utils.sta_processing import load_sta_and_extract_filters
+
+
+def _matching_filter_rows(available_ids: Any, requested_ids: Any, session: str) -> list[int]:
+    available = np.asarray(available_ids)
+    requested = np.asarray(requested_ids)
+    if available.ndim != 1 or requested.ndim != 1:
+        raise ValueError(f"Neuron IDs for session {session!r} must be one-dimensional")
+
+    rows = []
+    for neuron_id in requested:
+        matches = np.flatnonzero(available == neuron_id)
+        if len(matches) != 1:
+            raise ValueError(f"Filter bank has no unique row for neuron {neuron_id!r} in session {session!r}")
+        rows.append(int(matches[0]))
+    return rows
 
 
 class SpatialContrastReadout(Readout):
     """Single-session, multi-neuron Spatial Contrast readout.
 
-    Each neuron has frozen spatial and temporal filters (from pre-computed STAs)
-    and 4 learnable scalar parameters: w (contrast weight) and a, b, c
-    (nonlinearity shape).
+    Each neuron has provided spatial and temporal filters and 4 learnable scalar
+    parameters: w (contrast weight) and a, b, c
+    (nonlinearity shape). Optionally, the temporal filter and a Gaussian
+    parameterization of the spatial filter are learned as well.
 
     The forward pass processes neurons in chunks to limit GPU memory:
     for each chunk of K neurons, temporal filtering (conv1d) and spatial
@@ -37,8 +56,9 @@ class SpatialContrastReadout(Readout):
     Args:
         in_shape: (channels, time, height, width) of core output.
         outdims: Number of neurons in this session.
-        spatial_filters: Frozen spatial filters, shape [N, H, W].
-        temporal_filters: Frozen temporal filters, shape [N, T_filter].
+        spatial_filters: Initial spatial filters, shape [N, H, W].
+        temporal_filters: Initial temporal filters, shape [N, T_filter] or
+            [N, channels, T_filter].
         w_init: Initial contrast weight.
         a_init: Initial output scaling (nl_a).
         b_init: Initial input gain (nl_b).
@@ -46,12 +66,22 @@ class SpatialContrastReadout(Readout):
         mean_activity: Optional mean activity for bias initialization.
         neuron_chunk_size: Max neurons processed at once in forward pass.
             Controls the memory/speed trade-off. Default 32 works on 8 GB GPUs.
+        learnable_filters: Learn temporal filters and Gaussian RF center/size.
+        temporal_smoothness_reg: Weight on temporal second differences.
+        spatial_center_reg: Weight on RF center displacement from initialization.
+        spatial_scale_reg: Weight on log RF scale displacement from initialization.
     """
 
     # Registered buffers (declared for type checking)
     spatial_filters: torch.Tensor
     temporal_filters: torch.Tensor
     sf_sums: torch.Tensor
+    spatial_indices: torch.Tensor
+    spatial_weights: torch.Tensor
+    spatial_grid_y: torch.Tensor
+    spatial_grid_x: torch.Tensor
+    initial_spatial_mu: torch.Tensor
+    initial_spatial_log_sigma: torch.Tensor
 
     def __init__(
         self,
@@ -65,19 +95,92 @@ class SpatialContrastReadout(Readout):
         c_init: float = -5.0,
         mean_activity: Float[torch.Tensor, " neurons"] | None = None,
         neuron_chunk_size: int = 32,
+        learnable_filters: bool = False,
+        temporal_smoothness_reg: float = 0.0,
+        spatial_center_reg: float = 0.0,
+        spatial_scale_reg: float = 0.0,
     ):
         super().__init__()
-        assert spatial_filters.shape[0] == outdims
-        assert temporal_filters.shape[0] == outdims
+        if spatial_filters.shape != (outdims, *in_shape[-2:]):
+            raise ValueError(f"Expected spatial filters {(outdims, *in_shape[-2:])}, got {spatial_filters.shape}")
+        if temporal_filters.ndim == 2:
+            valid_temporal_shape = in_shape[0] == 1 and temporal_filters.shape[0] == outdims
+        else:
+            valid_temporal_shape = temporal_filters.ndim == 3 and temporal_filters.shape[:2] == (
+                outdims,
+                in_shape[0],
+            )
+        if not valid_temporal_shape:
+            raise ValueError(
+                f"Expected temporal filters [neurons, time] for one channel or "
+                f"[neurons, {in_shape[0]}, time], got {temporal_filters.shape}"
+            )
+        if temporal_filters.shape[-1] > in_shape[1]:
+            raise ValueError("Temporal filters cannot be longer than the input")
+        if neuron_chunk_size < 1:
+            raise ValueError("neuron_chunk_size must be positive")
 
         self.outdims = outdims
         self.in_shape = in_shape
         self.neuron_chunk_size = neuron_chunk_size
+        self.learnable_filters = learnable_filters
+        self.temporal_smoothness_reg = temporal_smoothness_reg
+        self.spatial_center_reg = spatial_center_reg
+        self.spatial_scale_reg = spatial_scale_reg
 
-        # Frozen filters as buffers
         self.register_buffer("spatial_filters", spatial_filters)
-        self.register_buffer("temporal_filters", temporal_filters)
+        if learnable_filters:
+            self.temporal_filters = nn.Parameter(temporal_filters.clone())
+        else:
+            self.register_buffer("temporal_filters", temporal_filters)
         self.register_buffer("sf_sums", spatial_filters.sum(dim=(-2, -1)))
+
+        height, width = in_shape[-2:]
+        grid_y, grid_x = torch.meshgrid(
+            torch.arange(height, dtype=spatial_filters.dtype),
+            torch.arange(width, dtype=spatial_filters.dtype),
+            indexing="ij",
+        )
+        weights = spatial_filters.abs()
+        weight_sums = weights.sum(dim=(-2, -1)).clamp_min(1e-8)
+        initial_mu = torch.stack(
+            (
+                einsum(weights, grid_y, "n h w, h w -> n") / weight_sums,
+                einsum(weights, grid_x, "n h w, h w -> n") / weight_sums,
+            ),
+            dim=-1,
+        )
+        initial_variance = torch.stack(
+            (
+                einsum(weights, (grid_y[None] - initial_mu[:, 0, None, None]) ** 2, "n h w, n h w -> n") / weight_sums,
+                einsum(weights, (grid_x[None] - initial_mu[:, 1, None, None]) ** 2, "n h w, n h w -> n") / weight_sums,
+            ),
+            dim=-1,
+        )
+        initial_log_sigma = initial_variance.clamp_min(0.25).sqrt().log()
+        self.register_buffer("spatial_grid_y", grid_y, persistent=False)
+        self.register_buffer("spatial_grid_x", grid_x, persistent=False)
+        self.register_buffer("initial_spatial_mu", initial_mu, persistent=False)
+        self.register_buffer("initial_spatial_log_sigma", initial_log_sigma, persistent=False)
+        if learnable_filters:
+            self.spatial_mu = nn.Parameter(initial_mu.clone())
+            self.spatial_log_sigma = nn.Parameter(initial_log_sigma.clone())
+        else:
+            self.register_parameter("spatial_mu", None)
+            self.register_parameter("spatial_log_sigma", None)
+
+        # Sparse support keeps the fixed-filter model fast.
+        support_sizes = spatial_filters.ne(0).sum(dim=(-2, -1))
+        max_support = int(support_sizes.max())
+        spatial_indices = torch.zeros((outdims, max_support), dtype=torch.long)
+        spatial_weights = torch.zeros((outdims, max_support), dtype=spatial_filters.dtype)
+        flat_filters = spatial_filters.flatten(1)
+        for neuron, support_size in enumerate(support_sizes.tolist()):
+            indices = flat_filters[neuron].nonzero().flatten()
+            spatial_indices[neuron, :support_size] = indices
+            spatial_weights[neuron, :support_size] = flat_filters[neuron, indices]
+        self.register_buffer("spatial_indices", spatial_indices, persistent=False)
+        self.register_buffer("spatial_weights", spatial_weights, persistent=False)
 
         # Per-neuron learnable parameters
         self.w = nn.Parameter(torch.full((outdims,), w_init))
@@ -99,8 +202,20 @@ class SpatialContrastReadout(Readout):
         self.initialize_bias(mean_activity)
 
     def regularizer(self, reduction: Literal["sum", "mean", None] = "sum") -> torch.Tensor:
-        """No regularization needed for 4 params per neuron."""
-        return torch.tensor(0.0, device=self.w.device)
+        if not self.learnable_filters:
+            return torch.tensor(0.0, device=self.w.device)
+
+        kernels = self._normalized_temporal_filters()
+        temporal_penalty = kernels.diff(n=2, dim=-1).square().mean(dim=(-2, -1))
+        assert self.spatial_mu is not None and self.spatial_log_sigma is not None
+        center_penalty = (self.spatial_mu - self.initial_spatial_mu).square().mean(dim=-1)
+        scale_penalty = (self.spatial_log_sigma - self.initial_spatial_log_sigma).square().mean(dim=-1)
+        penalty = (
+            self.temporal_smoothness_reg * temporal_penalty
+            + self.spatial_center_reg * center_penalty
+            + self.spatial_scale_reg * scale_penalty
+        )
+        return self.apply_reduction(penalty, reduction)
 
     def _plot_weight_for_neuron(
         self,
@@ -110,7 +225,7 @@ class SpatialContrastReadout(Readout):
     ) -> None:
         ax_readout, ax_features = axes
 
-        spatial_filter = self.spatial_filters[neuron_id].detach().cpu().numpy()
+        spatial_filter = self._current_spatial_filters()[neuron_id].detach().cpu().numpy()
         spatial_abs_max = np.abs(spatial_filter).max()
         if spatial_abs_max == 0:
             spatial_abs_max = 1.0
@@ -141,39 +256,101 @@ class SpatialContrastReadout(Readout):
     def number_of_neurons(self) -> int:
         return self.outdims
 
+    def apply_constraints(self) -> None:
+        with torch.no_grad():
+            self.w.clamp_(min=0)
+            self.nl_a.clamp_(min=0)
+            if self.learnable_filters:
+                assert self.spatial_mu is not None and self.spatial_log_sigma is not None
+                self.spatial_mu[:, 0].clamp_(0, self.in_shape[-2] - 1)
+                self.spatial_mu[:, 1].clamp_(0, self.in_shape[-1] - 1)
+                self.spatial_log_sigma.clamp_(
+                    min=float(np.log(0.5)),
+                    max=float(np.log(max(self.in_shape[-2:]))),
+                )
+
+    def _normalized_temporal_filters(self) -> torch.Tensor:
+        kernels = self.temporal_filters
+        if kernels.ndim == 2:
+            kernels = kernels[:, None, :]
+        if self.learnable_filters:
+            kernels = kernels / kernels.flatten(1).norm(dim=1).clamp_min(1e-8)[:, None, None]
+        return kernels
+
+    def _current_spatial_filters(self) -> torch.Tensor:
+        if not self.learnable_filters:
+            return self.spatial_filters
+        assert self.spatial_mu is not None and self.spatial_log_sigma is not None
+        sigma = self.spatial_log_sigma.exp()
+        distance = (self.spatial_grid_y[None] - self.spatial_mu[:, 0, None, None]) ** 2 / sigma[
+            :, 0, None, None
+        ] ** 2 + (self.spatial_grid_x[None] - self.spatial_mu[:, 1, None, None]) ** 2 / sigma[:, 1, None, None] ** 2
+        filters = torch.exp(-0.5 * distance)
+        return filters / filters.sum(dim=(-2, -1), keepdim=True).clamp_min(1e-8)
+
+    def _nonlinearity(
+        self,
+        imean: torch.Tensor,
+        lsc: torch.Tensor,
+        chunk_start: int,
+        chunk_end: int,
+    ) -> torch.Tensor:
+        combined = imean + self.w[chunk_start:chunk_end][None, :, None] * lsc
+        return self.nl_a[chunk_start:chunk_end][None, :, None] * F.softplus(
+            self.nl_b[chunk_start:chunk_end][None, :, None] * combined + self.nl_c[chunk_start:chunk_end][None, :, None]
+        )
+
     def _forward_chunk(
         self,
-        x_flat: Float[torch.Tensor, "bhw 1 time"],
+        x: Float[torch.Tensor, "batch channels time pixels"],
         chunk_start: int,
         chunk_end: int,
         batch: int,
-        h: int,
-        w: int,
     ) -> Float[torch.Tensor, "batch chunk time_out"]:
         """Process a chunk of neurons: temporal filtering + spatial contraction + nonlinearity."""
-        # Temporal filtering: standard conv1d with K output channels, 1 input channel
-        kernels = self.temporal_filters[chunk_start:chunk_end, None, :]  # [K, 1, t_filter]
-        tf_chunk = F.conv1d(x_flat, kernels)  # [(b*h*w), K, t_out]
-        tf_chunk = rearrange(tf_chunk, "(b h w) k t -> b k t h w", b=batch, h=h, w=w)
+        # Select only nonzero RF pixels and apply each neuron's temporal filter
+        # with grouped convolution.
+        indices = self.spatial_indices[chunk_start:chunk_end]
+        weights = self.spatial_weights[chunk_start:chunk_end]
+        selected = x[..., indices]
+        selected = rearrange(selected, "b c t k p -> (b p) (k c) t")
+        kernels = self._normalized_temporal_filters()[chunk_start:chunk_end]
+        tf_chunk = F.conv1d(selected, kernels, groups=len(kernels))
+        tf_chunk = rearrange(tf_chunk, "(b p) k t -> b k t p", b=batch, p=indices.shape[1])
 
         # Spatially-weighted mean
-        sf = self.spatial_filters[chunk_start:chunk_end]  # [K, H, W]
         sf_sums = self.sf_sums[chunk_start:chunk_end] + 1e-8  # [K]
-        imean = einsum(tf_chunk, sf, "b k t h w, k h w -> b k t") / sf_sums[None, :, None]
+        imean = einsum(tf_chunk, weights, "b k t p, k p -> b k t") / sf_sums[None, :, None]
 
         # Local spatial contrast via variance decomposition: Var = E[x^2] - E[x]^2
-        mean_sq = einsum(tf_chunk**2, sf, "b k t h w, k h w -> b k t") / sf_sums[None, :, None]
+        mean_sq = einsum(tf_chunk**2, weights, "b k t p, k p -> b k t") / sf_sums[None, :, None]
         variance = mean_sq - imean**2
         lsc = torch.sqrt(torch.clamp(variance, min=1e-6))
 
-        # Per-neuron nonlinearity
-        w_chunk = self.w[chunk_start:chunk_end][None, :, None]
-        combined = imean + w_chunk * lsc
+        return self._nonlinearity(imean, lsc, chunk_start, chunk_end)
 
-        nl_a = self.nl_a[chunk_start:chunk_end][None, :, None]
-        nl_b = self.nl_b[chunk_start:chunk_end][None, :, None]
-        nl_c = self.nl_c[chunk_start:chunk_end][None, :, None]
-        return nl_a * F.softplus(nl_b * combined + nl_c)  # [b, K, t_out]
+    def _forward_learnable_chunk(
+        self,
+        x: Float[torch.Tensor, "batch_pixels channels time"],
+        spatial_filters: Float[torch.Tensor, "neurons height width"],
+        chunk_start: int,
+        chunk_end: int,
+        batch: int,
+    ) -> Float[torch.Tensor, "batch chunk time_out"]:
+        kernels = self._normalized_temporal_filters()[chunk_start:chunk_end]
+        filtered = F.conv1d(x, kernels)
+        filtered = rearrange(
+            filtered,
+            "(b h w) k t -> b k t h w",
+            b=batch,
+            h=self.in_shape[-2],
+            w=self.in_shape[-1],
+        )
+        weights = spatial_filters[chunk_start:chunk_end]
+        imean = einsum(filtered, weights, "b k t h w, k h w -> b k t")
+        mean_sq = einsum(filtered.square(), weights, "b k t h w, k h w -> b k t")
+        lsc = torch.sqrt((mean_sq - imean.square()).clamp_min(1e-6))
+        return self._nonlinearity(imean, lsc, chunk_start, chunk_end)
 
     def forward(
         self,
@@ -181,18 +358,33 @@ class SpatialContrastReadout(Readout):
         data_key: str | None = None,
         **kwargs,
     ) -> Float[torch.Tensor, "batch time_out neurons"]:
+        self.apply_constraints()
         batch, channels, time, h, w = x.shape
+        if channels != self.in_shape[0] or (h, w) != tuple(self.in_shape[-2:]):
+            expected = f"(*, {self.in_shape[0]}, time, {self.in_shape[-2]}, {self.in_shape[-1]})"
+            raise ValueError(f"Expected input shape {expected}, got {x.shape}")
         n = self.outdims
 
-        # Flatten spatial dims for conv1d: each pixel is an independent "batch" element
-        x_flat = rearrange(x, "b 1 t h w -> (b h w) 1 t")
+        if self.learnable_filters:
+            x_for_readout = rearrange(x, "b c t h w -> (b h w) c t")
+            current_spatial_filters = self._current_spatial_filters()
+        else:
+            x_for_readout = x.flatten(-2)
+            current_spatial_filters = self.spatial_filters
 
-        # Process neurons in chunks to limit peak memory
-        # Peak 5D tensor per chunk: [batch, chunk_size, t_out, H, W]
         chunk_outputs: list[torch.Tensor] = []
         for chunk_start in range(0, n, self.neuron_chunk_size):
             chunk_end = min(chunk_start + self.neuron_chunk_size, n)
-            chunk_out = self._forward_chunk(x_flat, chunk_start, chunk_end, batch, h, w)
+            if self.learnable_filters:
+                chunk_out = self._forward_learnable_chunk(
+                    x_for_readout,
+                    current_spatial_filters,
+                    chunk_start,
+                    chunk_end,
+                    batch,
+                )
+            else:
+                chunk_out = self._forward_chunk(x_for_readout, chunk_start, chunk_end, batch)
             chunk_outputs.append(chunk_out)
 
         output = torch.cat(chunk_outputs, dim=1)  # [b, N, t_out]
@@ -211,6 +403,10 @@ class MultiSpatialContrastReadout(MultiReadoutBase):
         n_neurons_dict: Mapping from session key to number of neurons.
         spatial_filters_dict: Per-session spatial filter tensors [N, H, W].
         temporal_filters_dict: Per-session temporal filter tensors [N, T_filter].
+        filter_bank_path: Torch file containing the two filter dictionaries and,
+            optionally, ``neuron_ids_dict`` for stable-ID-based row selection.
+        sta_dir: Alternative source directory for per-neuron STA files.
+        data_info: Runtime session metadata injected by ``UnifiedCoreReadout``.
         w_init: Initial contrast weight.
         a_init: Initial output scaling.
         b_init: Initial input gain.
@@ -225,8 +421,15 @@ class MultiSpatialContrastReadout(MultiReadoutBase):
         self,
         in_shape: tuple[int, int, int, int],
         n_neurons_dict: dict[str, int],
-        spatial_filters_dict: dict[str, Float[torch.Tensor, "neurons height width"]],
-        temporal_filters_dict: dict[str, Float[torch.Tensor, "neurons t_filter"]],
+        spatial_filters_dict: dict[str, Float[torch.Tensor, "neurons height width"]] | None = None,
+        temporal_filters_dict: dict[str, Float[torch.Tensor, "neurons t_filter"]] | None = None,
+        filter_bank_path: str | Path | None = None,
+        sta_dir: str | Path | None = None,
+        sta_file_pattern: str = "cell_data_{retina_index}_WN_stas_cell_{cell_index}.npy",
+        flip_sta: bool = False,
+        temporal_crop_frames: int | None = 30,
+        sigma_contour: float = 3.0,
+        data_info: dict[str, Any] | None = None,
         w_init: float = 0.0,
         a_init: float = 4.0,
         b_init: float = 1.0,
@@ -234,7 +437,83 @@ class MultiSpatialContrastReadout(MultiReadoutBase):
         mean_activity_dict: dict[str, Float[torch.Tensor, " neurons"]] | None = None,
         readout_reg_avg: bool = False,
         neuron_chunk_size: int = 32,
+        learnable_filters: bool = False,
+        temporal_smoothness_reg: float = 0.0,
+        spatial_center_reg: float = 0.0,
+        spatial_scale_reg: float = 0.0,
     ):
+        direct_filters = spatial_filters_dict is not None or temporal_filters_dict is not None
+        if (spatial_filters_dict is None) != (temporal_filters_dict is None):
+            raise ValueError("spatial_filters_dict and temporal_filters_dict must be provided together")
+        if sum((direct_filters, filter_bank_path is not None, sta_dir is not None)) != 1:
+            raise ValueError("Provide exactly one SC filter source: dictionaries, filter_bank_path, or sta_dir")
+
+        available_neuron_ids = None
+        if filter_bank_path is not None:
+            filter_bank = torch.load(
+                get_local_file_path(Path(filter_bank_path).as_posix()), map_location="cpu", weights_only=True
+            )
+            spatial_filters_dict = filter_bank["spatial_filters_dict"]
+            temporal_filters_dict = filter_bank["temporal_filters_dict"]
+            available_neuron_ids = filter_bank.get("neuron_ids_dict")
+        elif sta_dir is not None:
+            if data_info is None:
+                raise ValueError("data_info is required when loading SC filters from STAs")
+            spatial_filters_dict, temporal_filters_dict = {}, {}
+            local_sta_dir = get_local_file_path(Path(sta_dir).as_posix())
+            for session_key in n_neurons_dict:
+                cell_indices = data_info.get("sessions_kwargs", {}).get(session_key, {}).get("cell_indices")
+                if cell_indices is None:
+                    cell_indices = data_info.get("neuron_ids_dict", {}).get(session_key)
+                if cell_indices is None:
+                    raise ValueError(f"Neuron IDs are required to load STA filters for session {session_key!r}")
+                filters = [
+                    load_sta_and_extract_filters(
+                        sta_dir=local_sta_dir,
+                        file_name=sta_file_pattern.format(retina_index=session_key, cell_index=cell_index),
+                        flip_sta=flip_sta,
+                        target_spatial_shape=in_shape[-2:],
+                        temporal_crop_frames=temporal_crop_frames,
+                        sigma_contour=sigma_contour,
+                    )[:2]
+                    for cell_index in cell_indices
+                ]
+                spatial_filters_dict[session_key] = torch.stack([torch.from_numpy(x[0]) for x in filters])
+                temporal_filters_dict[session_key] = torch.stack([torch.from_numpy(x[1]) for x in filters])
+
+        if spatial_filters_dict is None or temporal_filters_dict is None:
+            raise RuntimeError("SC filter source resolution failed")
+        missing_sessions = set(n_neurons_dict) - spatial_filters_dict.keys() | (
+            set(n_neurons_dict) - temporal_filters_dict.keys()
+        )
+        if missing_sessions:
+            raise ValueError(f"SC filters are missing sessions: {sorted(missing_sessions)}")
+
+        selected_neuron_ids = {} if data_info is None else data_info.get("neuron_ids_dict", {})
+        resolved_spatial_filters = {}
+        resolved_temporal_filters = {}
+        for session_key, n_neurons in n_neurons_dict.items():
+            spatial_filters = spatial_filters_dict[session_key]
+            temporal_filters = temporal_filters_dict[session_key]
+            if available_neuron_ids is not None and session_key in selected_neuron_ids:
+                if session_key not in available_neuron_ids:
+                    raise ValueError(f"Filter bank neuron IDs are missing session {session_key!r}")
+                rows = _matching_filter_rows(
+                    available_neuron_ids[session_key],
+                    selected_neuron_ids[session_key],
+                    session_key,
+                )
+                spatial_filters = spatial_filters[rows]
+                temporal_filters = temporal_filters[rows]
+            if spatial_filters.shape[0] != n_neurons or temporal_filters.shape[0] != n_neurons:
+                raise ValueError(
+                    f"Session {session_key!r} has {n_neurons} neurons but "
+                    f"{spatial_filters.shape[0]} spatial and {temporal_filters.shape[0]} temporal filters. "
+                    "Store neuron_ids_dict in the filter bank to support neuron selection."
+                )
+            resolved_spatial_filters[session_key] = spatial_filters
+            resolved_temporal_filters[session_key] = temporal_filters
+
         # Bypass MultiReadoutBase.__init__ since we need per-session filter tensors
         nn.ModuleDict.__init__(self)
 
@@ -246,6 +525,10 @@ class MultiSpatialContrastReadout(MultiReadoutBase):
             "b_init": b_init,
             "c_init": c_init,
             "neuron_chunk_size": neuron_chunk_size,
+            "learnable_filters": learnable_filters,
+            "temporal_smoothness_reg": temporal_smoothness_reg,
+            "spatial_center_reg": spatial_center_reg,
+            "spatial_scale_reg": spatial_scale_reg,
         }
         self.readout_reg_avg = readout_reg_avg
         self.readout_reg_reduction: Literal["mean", "sum"] = "mean" if readout_reg_avg else "sum"
@@ -257,13 +540,26 @@ class MultiSpatialContrastReadout(MultiReadoutBase):
                 SpatialContrastReadout(
                     in_shape=in_shape,
                     outdims=n_neurons_dict[data_key],
-                    spatial_filters=spatial_filters_dict[data_key],
-                    temporal_filters=temporal_filters_dict[data_key],
+                    spatial_filters=resolved_spatial_filters[data_key],
+                    temporal_filters=resolved_temporal_filters[data_key],
                     w_init=w_init,
                     a_init=a_init,
                     b_init=b_init,
                     c_init=c_init,
                     mean_activity=mean_activity,
                     neuron_chunk_size=neuron_chunk_size,
+                    learnable_filters=learnable_filters,
+                    temporal_smoothness_reg=temporal_smoothness_reg,
+                    spatial_center_reg=spatial_center_reg,
+                    spatial_scale_reg=spatial_scale_reg,
                 ),
             )
+
+    def add_sessions(
+        self,
+        n_neurons_dict: dict[str, int],
+        mean_activity_dict: dict[str, Float[torch.Tensor, " neurons"]] | None = None,
+    ) -> None:
+        raise NotImplementedError(
+            "Adding SC sessions requires session-specific filters; construct a new readout instead"
+        )


### PR DESCRIPTION
Work in progress.

## Goals:
- Fit spatial contrast model into core readout framework (core = pass through, readout = spatial contrast readout)
- Evaluate performance (not sure if this makes sense on datasets that did not record activity in response to white noise stimuli, though)
- `openretina/data_io/hoefling_2024/spatial_contrast.py` is codex try to estimate the receptive fields based on natural movies


### Rough results for hoefling data
Unsure if these results should be trusted before the code is double checked, and still then on the hoefling data there's the disclaimer that it does not contain any white noise recordings. Disclaimer: somehow temporal lag is 29 here, so off by one.

```
Data split: test
Temporal lag: 29
--------------------------------------------------------------------------------
Total neurons: 3144
Variance ratio cutoff: 0.15
Neurons above var_ratio threshold (>=0.15): 2405
Neurons excluded: 739 (23.5%)
--------------------------------------------------------------------------------

Trial/repeats-averaged metrics (computed on neurons above var_ratio threshold):
(Number of trials/repeats: 3 (constant across all sessions))
--------------------------------------------------------------------------------
  Correlation                   : 0.273
  MSE                           : 2.287
  FEVe                          : 0.001
  FEV (expl. var ratio)         : 0.418
  Poisson loss                  : 4.996

Per-trial metrics (computed on neurons above var_ratio threshold):
--------------------------------------------------------------------------------
  Correlation                   : 0.220 (+/-0.018)
  MSE                           : 2.617 (+/-0.075)
================================================================================
```
