### PR TITLE
Fixes for metadata stored in model checkpoints

### DIFF
--- a/configs/hoefling_2024_core_readout_low_res.yaml
+++ b/configs/hoefling_2024_core_readout_low_res.yaml
@@ -27,7 +27,8 @@ model:
   in_shape: [2, 150, 18, 16]
 
 data_io:
-  retina_pixel_size_um: 50 # 4x bigger than high res model
+  data_info:
+    retina_pixel_size_um: 50 # 4x bigger than high res model
 
 paths:
   load_model_path: null

--- a/configs/hoefling_2024_core_readout_low_res_hyperparams_search.yaml
+++ b/configs/hoefling_2024_core_readout_low_res_hyperparams_search.yaml
@@ -27,7 +27,8 @@ dataloader:
   batch_size: 64
 
 data_io:
-  retina_pixel_size_um: 50 # 4x bigger than high res model
+  data_info:
+    retina_pixel_size_um: 50 # 4x bigger than high res model
 
 objective_target: val_evaluation_loss
 

--- a/configs/hoefling_2024_core_readout_low_res_lnp.yaml
+++ b/configs/hoefling_2024_core_readout_low_res_lnp.yaml
@@ -25,7 +25,8 @@ model:
   in_shape: [2, 150, 18, 16]
 
 data_io:
-  retina_pixel_size_um: 50 # 4x bigger than high res model
+  data_info:
+    retina_pixel_size_um: 50 # 4x bigger than high res model
 
 paths:
   load_model_path: null

--- a/openretina/modules/readout/base.py
+++ b/openretina/modules/readout/base.py
@@ -66,7 +66,8 @@ class Readout(nn.Module, ABC):
             warnings.warn("Readout is NOT initialized with mean activity but with 0!")
             self.bias.data.fill_(0)
         else:
-            self.bias.data = mean_activity
+            with torch.no_grad():
+                self.bias.copy_(mean_activity)
 
     def __repr__(self) -> str:
         return super().__repr__() + " [{}]\n".format(self.__class__.__name__)

--- a/openretina/modules/readout/linear_nonlinear_poison.py
+++ b/openretina/modules/readout/linear_nonlinear_poison.py
@@ -130,4 +130,5 @@ class LNPReadout(Readout):
 
     def initialize(self, mean_activity: Float[torch.Tensor, " n_neurons"] | None = None) -> None:
         if self.inner_product_kernel.bias is not None and mean_activity is not None:
-            self.inner_product_kernel.bias.data = mean_activity
+            with torch.no_grad():
+                self.inner_product_kernel.bias.copy_(mean_activity)


### PR DESCRIPTION
## Pixel Size

The pixel size of the low res models was not written correctly, as the config was slightly off (see the diff). The current uploaded models claim both low_res and high_res models have a pixel size of 12.5um:

```
>>> from openretina.models import load_core_readout_from_remote
>>> model_low_res = load_core_readout_from_remote("hoefling_2024_cnn_low_res.ckpt", "cpu")
>>> model_high_res = load_core_readout_from_remote("hoefling_2024_cnn_high_res.ckpt", "cpu")
>>> model_low_res.data_info["retina_pixel_size_um"]
12.5
>>> model_high_res.data_info["retina_pixel_size_um"]
12.5
```

## Mean Activity Dict
We accidentally updated the mean activity dict during gradient descent:

This is the mean activity dict that is loaded from the dataloader:
> mean_activity_dict["session_1_ventral1_20200226"]
tensor([1.6096, 1.8878, 1.8371, 1.4248, 2.2134, 1.2773, 1.9525, 1.0842, 1.4127,
        1.4985, 1.1791, 1.5670, 1.5992, 1.6681, 1.5591, 2.4102, 1.9612, 1.8201,
        1.2381, 1.2290, 1.5100, 2.1231, 1.3186, 1.1392, 1.4222, 1.3222, 1.2301,
        1.2212, 1.1974, 1.3163, 1.6716, 1.2099, 1.3319, 1.4130, 1.2039, 1.0056,
        1.1480, 1.0159, 1.1519, 1.2238, 1.4399, 1.4190, 2.0704, 1.5387, 1.7132,
        1.8599, 1.4381, 1.8645, 1.6108, 1.5615, 1.6128, 1.2717, 1.0368, 1.5235,
        1.4016, 1.3309, 1.3377, 1.3967, 1.1374, 1.4638, 1.1762, 1.2841, 1.4298,
        1.5941, 1.4641, 2.0509, 1.7528, 1.1087, 1.2584, 1.3270, 1.4480, 1.5824,
        1.2495, 1.3981, 1.0536, 1.1237, 1.2738, 1.3587, 1.5909, 1.2335])

Here is the one stored in the checkpoint:
> model_low_res.data_info["mean_activity_dict"]["session_1_ventral1_20200226"]
tensor([1.4143, 1.7755, 1.7024, 1.1173, 2.1142, 0.9608, 1.7917, 0.6160, 1.1603,
        1.2728, 0.7920, 1.3020, 1.4296, 1.4850, 1.3366, 2.3300, 1.8366, 1.6377,
        0.9587, 0.8974, 1.2767, 2.0184, 1.0452, 0.7258, 1.1410, 1.0715, 0.9156,
        0.9210, 0.9015, 1.0829, 1.5505, 0.9219, 1.0918, 1.1519, 0.8337, 0.5751,
        0.6432, 0.5232, 0.6930, 0.8972, 1.1256, 1.2194, 2.0039, 1.2607, 1.4401,
        1.7305, 1.2311, 1.7472, 1.4485, 1.3764, 1.4262, 0.9623, 0.5619, 1.3700,
        1.1167, 1.0773, 1.0543, 1.0833, 0.7024, 1.2415, 0.8312, 1.0081, 1.2080,
        1.3463, 1.2635, 1.9535, 1.5855, 0.7359, 0.8880, 0.9828, 1.1680, 1.3602,
        0.8476, 1.1073, 0.5957, 0.7408, 0.9581, 1.0688, 1.3847, 0.9032])

This happened as we only stored the reference to the mean activity dict in the bias, so gradient descent steps both updated the bias and the mean_activity_dict tensors. By copying the values this does not happen anymore.