### PR TITLE
Correctly minimize loss in lr_scheduler for goldin models

### DIFF
--- a/configs/goldin_2022_core_readout.yaml
+++ b/configs/goldin_2022_core_readout.yaml
@@ -1,7 +1,7 @@
 defaults:
   - data_io: goldin_2022
   - dataloader: goldin_2022
-  - model: base_core_readout
+  - model: core_gaussian_readout
   - optimizer: adamw
   - lr_scheduler: reduce_lr_on_plateau
   - training_callbacks:
@@ -34,20 +34,38 @@ data_io:
 # Overwrite model defaults
 model:
   in_shape: [1, 1, 108, 108]
-  hidden_channels: [4]
+  hidden_channels: [64, 64]
+  learning_rate: 0.005
   core:
-    temporal_kernel_sizes: [1]
-    spatial_kernel_sizes: [30]
+    temporal_kernel_sizes: [1, 1]
+    spatial_kernel_sizes: [11, 11]
+    gamma_input: 0.28244013235889076
+    gamma_in_sparse: 0.01168774607827805
+    gamma_hidden: 0.37605406981720907
     gamma_temporal: 0.0
-    gamma_input: 0.4654576767872573
+    input_padding: false
+    hidden_padding: [0, 0, 0]
+    maxpool_every_n_layers: null
+    downsample_input_kernel_size: null
     convolution_type: "time_independent"
+    dropout_rate: 0.01175505972706517
+    cut_first_n_frames: 0
   readout:
-    mask_l1_reg: 0.0  # 5.924553274051563
-    feature_weights_l1_reg: 0.0  # 6.075840974162483
-    positive: false
+    bias: true
+    gamma: 0.41481588699036054
+    init_mu_range: 0.05578578551827034
+    init_sigma_range: 0.389355744189837
+    reg_avg: false
+    batch_sample: true
+    align_corners: true
+    gauss_type: "full"
+    grid_mean_predictor: null
+    shared_features: null
+    init_grid: null
+    shared_grid: null
   evaluation_loss:
     _target_: openretina.modules.losses.poisson.PoissonLoss3d
-    avg: True
+    avg: true
 
 lr_scheduler:
   mode: min

--- a/configs/goldin_2022_core_readout.yaml
+++ b/configs/goldin_2022_core_readout.yaml
@@ -49,6 +49,9 @@ model:
     _target_: openretina.modules.losses.poisson.PoissonLoss3d
     avg: True
 
+lr_scheduler:
+  mode: min
+
 matmul_precision:
   _target_: torch.set_float32_matmul_precision
   precision: highest

--- a/configs/hoefling_2024_core_readout_low_res_gru.yaml
+++ b/configs/hoefling_2024_core_readout_low_res_gru.yaml
@@ -1,0 +1,49 @@
+# Architecture recovered from models/hoefling_2024_GRU_low_res_model.ckpt.
+#
+# The checkpoint was produced with the legacy GRUCoreReadout class, but its
+# saved core_use_gru flag is false and its state dict contains no GRU weights.
+# Keep use_gru disabled here so this config describes the uploaded checkpoint
+# exactly; setting it to true defines a different, randomly initialized model.
+defaults:
+  - hoefling_2024_core_readout_low_res
+  - override model: GRU_core_readout
+  - _self_
+
+exp_name: hoefling_2024_core_readout_low_res_gru
+
+model:
+  in_shape: [2, 150, 18, 16]
+  hidden_channels: [32, 64]
+  learning_rate: 0.01
+
+  core:
+    temporal_kernel_sizes: [21, 11]
+    spatial_kernel_sizes: [11, 5]
+    gamma_hidden: 0.0
+    gamma_input: 0.3
+    gamma_in_sparse: 1.0
+    gamma_temporal: 40.0
+    bias: true
+    input_padding: false
+    hidden_padding: true
+    use_gru: false
+    use_projections: true
+    batch_adaptation: false
+    convolution_type: custom_separable
+    gru_kwargs:
+      rec_channels: 64
+      input_kern: 4
+      rec_kern: 4
+      groups: 1
+      gamma_rec: 1
+      pad_input: true
+
+  readout:
+    scale: true
+    bias: true
+    gaussian_mean_scale: 6.0
+    gaussian_var_scale: 4.0
+    positive: true
+    mask_l1_reg: 0.1
+    feature_weights_l1_reg: 0.4
+    readout_reg_avg: false

--- a/configs/vystrcilova_2024_nm_cnn.yaml
+++ b/configs/vystrcilova_2024_nm_cnn.yaml
@@ -4,7 +4,7 @@ defaults:
   - dataloader: sridhar_nm_2025
   - model: core_gaussian_readout
   - optimizer: adamw
-  - lr_scheduler: reduce_lr_on_plateau
+  - lr_scheduler: one_cycle_lr
   - training_callbacks:
       - early_stopping
       - lr_monitor
@@ -20,7 +20,7 @@ seed: 42
 check_stimuli_responses_match: false
 
 dataloader:
-  batch_size: 64
+  batch_size: 16
 
 model:
   in_shape:
@@ -28,6 +28,35 @@ model:
     - ${data_io.time_bins}
     - ${data_io.stimulus_height}
     - ${data_io.stimulus_width}
+  hidden_channels: [64, 64, 64]
+  learning_rate: 0.005
+  core:
+    temporal_kernel_sizes: [15, 11, 7]
+    spatial_kernel_sizes: [21, 15, 11]
+    gamma_input: 0.4697500757926789
+    gamma_in_sparse: 0.2989540104057545
+    gamma_hidden: 0.44741472694032014
+    gamma_temporal: 92.19523607880937
+    input_padding: false
+    hidden_padding: [0, 0, 0]
+    maxpool_every_n_layers: null
+    downsample_input_kernel_size: null
+    convolution_type: "custom_separable"
+    dropout_rate: 0.03097237571817182
+    cut_first_n_frames: 0
+  readout:
+    bias: true
+    gamma: 0.23618371929818793
+    init_mu_range: 0.07035228000974214
+    init_sigma_range: 0.19639864884346897
+    reg_avg: false
+    batch_sample: true
+    align_corners: true
+    gauss_type: "full"
+    grid_mean_predictor: null
+    shared_features: null
+    init_grid: null
+    shared_grid: null
 
 paths:
   load_model_path: null
@@ -41,7 +70,7 @@ matmul_precision:
   precision: highest
 
 trainer:
-  max_epochs: 100
+  max_epochs: 15
   accumulate_grad_batches: 1
   gradient_clip_val: 1
 

--- a/openretina/cli/train.py
+++ b/openretina/cli/train.py
@@ -58,7 +58,12 @@ def train_model(cfg: DictConfig) -> float | None:
         movies_dictionary=movies_dict,
     )
 
-    data_info = compute_data_info(neuron_data_dict, movies_dict, partial_data_info=cfg.data_io.get("data_info"))
+    data_info = compute_data_info(
+        neuron_data_dict,
+        movies_dict,
+        partial_data_info=cfg.data_io.get("data_info"),
+        train_dataloaders=dataloaders["train"],
+    )
 
     train_loader = data.DataLoader(
         LongCycler(dataloaders["train"], shuffle=True),

--- a/openretina/data_io/base.py
+++ b/openretina/data_io/base.py
@@ -191,6 +191,28 @@ def get_n_neurons_per_session(responses_dict: dict[str, ResponsesTrainTestSplit]
     return {name: responses.n_neurons for name, responses in responses_dict.items()}
 
 
+def compute_mean_activity(
+    responses: np.ndarray | torch.Tensor,
+    neuron_axis: int,
+) -> torch.Tensor:
+    """Compute per-neuron means from finite response samples only.
+
+    Neurons without any finite samples receive a zero mean. The readout
+    initializer subsequently floors those rates before applying an inverse link.
+    """
+    response_tensor = torch.as_tensor(responses, dtype=torch.float32)
+    if response_tensor.ndim != 2:
+        raise ValueError(f"Expected two-dimensional responses, got shape {tuple(response_tensor.shape)}")
+    if neuron_axis not in (0, 1):
+        raise ValueError(f"neuron_axis must be 0 or 1, got {neuron_axis}")
+
+    time_axis = 1 - neuron_axis
+    finite = torch.isfinite(response_tensor)
+    finite_count = finite.sum(dim=time_axis)
+    finite_sum = torch.where(finite, response_tensor, 0).sum(dim=time_axis)
+    return torch.where(finite_count > 0, finite_sum / finite_count.clamp_min(1), 0)
+
+
 @dataclass
 class DatasetStatistics:
     """Statistics about unique frames and transitions across sessions, computed from dataloaders.
@@ -270,6 +292,7 @@ def compute_data_info(
     neuron_data_dictionary: dict[str, ResponsesTrainTestSplit],
     movies_dictionary: dict[str, MoviesTrainTestSplit] | MoviesTrainTestSplit,
     partial_data_info: dict[str, Any] | None = None,
+    train_dataloaders: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """
     Computes information related to the data used to train a model, including the number of neurons, the shape of the
@@ -279,6 +302,8 @@ def compute_data_info(
     - neuron_data_dictionary: dictionary of responses for each session
     - movies_dictionary: dictionary of movies for each session
     - partial_data_info: dictionary of partial data info from the config, to be merged with the computed data info
+    - train_dataloaders: optional per-session training loaders. When provided, mean
+      activity is calculated from their datasets after the validation split.
 
     Returns:
     - data_info: dictionary containing various data info useful for downstream tasks, including the number of neurons,
@@ -287,12 +312,28 @@ def compute_data_info(
     """
     n_neurons_dict = get_n_neurons_per_session(neuron_data_dictionary)
 
-    # Compute mean activity for each session from training responses
+    if train_dataloaders is not None:
+        missing_sessions = set(neuron_data_dictionary) - set(train_dataloaders)
+        if missing_sessions:
+            raise ValueError(f"Missing training dataloaders for sessions: {sorted(missing_sessions)}")
+
+    # Compute mean activity for each session from training responses only.
     mean_activity_dict = {}
     for session_name, responses in neuron_data_dictionary.items():
-        # responses.train has shape (n_neurons, n_timepoints)
-        # Compute mean across time dimension
-        mean_activity = torch.tensor(responses.train.mean(axis=1), dtype=torch.float32)
+        if train_dataloaders is None:
+            # responses.train has shape (n_neurons, n_timepoints). This fallback is
+            # for datasets without a separate validation fold.
+            mean_activity = compute_mean_activity(responses.train, neuron_axis=0)
+        else:
+            train_dataset = train_dataloaders[session_name].dataset
+            if hasattr(train_dataset, "responses"):
+                mean_activity = compute_mean_activity(train_dataset.responses, neuron_axis=1)
+            elif hasattr(train_dataset, "mean_response"):
+                mean_activity = torch.as_tensor(train_dataset.mean_response, dtype=torch.float32).clone()
+            else:
+                raise ValueError(
+                    f"Training dataset for session {session_name!r} exposes neither responses nor mean_response"
+                )
         mean_activity_dict[session_name] = mean_activity
 
     if isinstance(movies_dictionary, MoviesTrainTestSplit):
@@ -332,7 +373,7 @@ def compute_data_info(
         session_name: responses.session_kwargs for session_name, responses in neuron_data_dictionary.items()
     }
 
-    return {
+    data_info = {
         "n_neurons_dict": n_neurons_dict,
         "mean_activity_dict": mean_activity_dict,
         "input_shape": input_shape,
@@ -341,3 +382,6 @@ def compute_data_info(
         "stim_std": stim_std,
         **(partial_data_info or {}),
     }
+    # Initialization statistics are always measured, never supplied by config.
+    data_info["mean_activity_dict"] = mean_activity_dict
+    return data_info

--- a/openretina/data_io/base_dataloader.py
+++ b/openretina/data_io/base_dataloader.py
@@ -10,7 +10,7 @@ from jaxtyping import Float
 from torch.utils.data import DataLoader, Dataset, Sampler
 from tqdm.auto import tqdm
 
-from openretina.data_io.base import MoviesTrainTestSplit, ResponsesTrainTestSplit
+from openretina.data_io.base import MoviesTrainTestSplit, ResponsesTrainTestSplit, compute_mean_activity
 
 log = logging.getLogger(__name__)
 
@@ -75,7 +75,8 @@ class MovieDataSet(Dataset):
 
         self.chunk_size = chunk_size
         # Calculate the mean response per neuron (used for bias init in the model)
-        self.mean_response = torch.mean(torch.Tensor(self.samples[1]), dim=0)
+        response_samples = cast(np.ndarray | torch.Tensor, self.samples[1])
+        self.mean_response = compute_mean_activity(response_samples, neuron_axis=1)
         self.group_assignment = group_assignment
         self.roi_coords = roi_coords
 

--- a/openretina/data_io/sridhar_2025/dataloaders.py
+++ b/openretina/data_io/sridhar_2025/dataloaders.py
@@ -213,6 +213,7 @@ class MarmosetMovieDataset(Dataset):
         self.time_chunk_size = time_chunk_size + self.frame_overhead
 
         self.cache: list[Any] = []
+        self.last_trial_index: int | None = None
         self.last_start_index = -1
         self.last_end_index = -1
 
@@ -375,7 +376,11 @@ class MarmosetMovieDataset(Dataset):
         fixations = self.fixations[int(starting_line) : int(ending_line)]
         frames = torch.zeros((self.time_chunk_size, self.img_h, self.img_w))
         for i, (fixation, index) in enumerate(zip(fixations, range(starting_img_index, ending_img_index))):
-            if (index >= self.last_start_index) and (index < self.last_end_index):
+            if (
+                trial_index == self.last_trial_index
+                and index >= self.last_start_index
+                and index < self.last_end_index
+            ):
                 img = self.cache[index - self.last_start_index]
             else:
                 img = torch.from_numpy(self.frames[fixation["img_index"]].astype(np.float32))
@@ -394,6 +399,7 @@ class MarmosetMovieDataset(Dataset):
         frames = torch.movedim(frames, 0, 2)
         frames = self.transform(frames)
         frames = torch.movedim(frames, 2, 0)
+        self.last_trial_index = trial_index
         self.last_start_index = starting_img_index
         self.last_end_index = ending_img_index
         self.cache = cache

--- a/openretina/modules/layers/convolutions.py
+++ b/openretina/modules/layers/convolutions.py
@@ -148,8 +148,8 @@ class TimeIndependentConv3D(nn.Module):
         )
 
     @property
-    def weight_spatial(self):
-        return self.conv.weight.data
+    def weight_spatial(self) -> torch.Tensor:
+        return self.conv.weight
 
     def forward(self, input_: torch.Tensor | tuple[torch.Tensor, str]) -> torch.Tensor:
         if type(input_) is torch.Tensor:

--- a/openretina/modules/readout/base.py
+++ b/openretina/modules/readout/base.py
@@ -6,12 +6,46 @@ https://github.com/sinzlab/neuralpredictors/blob/v0.3.0.pre/neuralpredictors/lay
 import os
 import warnings
 from abc import ABC, abstractmethod
-from typing import Any, Literal, Optional
+from typing import Any, Callable, Literal, Optional
 
 import matplotlib.pyplot as plt
 import torch
 import torch.nn as nn
 from jaxtyping import Float
+
+MIN_MEAN_RATE = 1e-6
+
+
+def sanitize_mean_rate(mean_rate: torch.Tensor, minimum_rate: float = MIN_MEAN_RATE) -> torch.Tensor:
+    """Return finite, positive rates suitable for an inverse output link."""
+    if not mean_rate.is_floating_point():
+        mean_rate = mean_rate.float()
+    return torch.nan_to_num(
+        mean_rate,
+        nan=minimum_rate,
+        posinf=minimum_rate,
+        neginf=minimum_rate,
+    ).clamp_min(minimum_rate)
+
+
+def softplus_inverse(mean_rate: torch.Tensor, minimum_rate: float = MIN_MEAN_RATE) -> torch.Tensor:
+    """Numerically stable inverse softplus for non-negative rate targets."""
+    safe_rate = sanitize_mean_rate(mean_rate, minimum_rate=minimum_rate)
+    return safe_rate + torch.log(-torch.expm1(-safe_rate))
+
+
+def initialize_bias_from_mean_rate(
+    bias: torch.Tensor,
+    mean_rate: torch.Tensor,
+    inverse_link: Callable[[torch.Tensor], torch.Tensor] = softplus_inverse,
+) -> None:
+    """Initialize a preactivation bias without aliasing the statistics tensor."""
+    safe_rate = sanitize_mean_rate(mean_rate.to(device=bias.device, dtype=bias.dtype))
+    preactivation_bias = inverse_link(safe_rate)
+    if not torch.isfinite(preactivation_bias).all():
+        raise ValueError("Inverse output link produced a non-finite readout bias")
+    with torch.no_grad():
+        bias.copy_(preactivation_bias)
 
 
 class Readout(nn.Module, ABC):
@@ -53,20 +87,26 @@ class Readout(nn.Module, ABC):
                 f"Reduction method '{reduction}' is not recognized. Valid values are ['mean', 'sum', None]"
             )
 
-    def initialize_bias(self, mean_activity: Optional[Float[torch.Tensor, " n_neurons"]] = None) -> None:
+    def initialize_bias(
+        self,
+        mean_activity: Optional[Float[torch.Tensor, " n_neurons"]] = None,
+        inverse_link: Callable[[torch.Tensor], torch.Tensor] = softplus_inverse,
+    ) -> None:
         """
         Initialize the biases in readout.
         Args:
             mean_activity: Tensor containing the mean activity of neurons.
+            inverse_link: Maps output rates to readout preactivations.
 
         Returns:
 
         """
         if mean_activity is None:
             warnings.warn("Readout is NOT initialized with mean activity but with 0!")
-            self.bias.data.fill_(0)
+            with torch.no_grad():
+                self.bias.fill_(0)
         else:
-            self.bias.data = mean_activity
+            initialize_bias_from_mean_rate(self.bias, mean_activity, inverse_link=inverse_link)
 
     def __repr__(self) -> str:
         return super().__repr__() + " [{}]\n".format(self.__class__.__name__)

--- a/openretina/modules/readout/factorized.py
+++ b/openretina/modules/readout/factorized.py
@@ -202,7 +202,7 @@ class FactorizedReadout(Readout):
         return self.outdims
 
     def initialize(self, mean_activity: Float[torch.Tensor, " outdims"] | None = None) -> None:
-        if mean_activity is not None:
+        if self.readout_bias and mean_activity is not None:
             self.initialize_bias(mean_activity)
 
 

--- a/openretina/modules/readout/factorized_gaussian.py
+++ b/openretina/modules/readout/factorized_gaussian.py
@@ -95,7 +95,8 @@ class GaussianMaskReadout(Readout):
         """
         Initialize bias using base helper to optionally use mean activity.
         """
-        self.initialize_bias(mean_activity)
+        if isinstance(self.bias, nn.Parameter):
+            self.initialize_bias(mean_activity)
 
     def feature_l1(self, average: bool = False) -> torch.Tensor:
         features_abs = self.features.abs()

--- a/openretina/modules/readout/linear_nonlinear_poison.py
+++ b/openretina/modules/readout/linear_nonlinear_poison.py
@@ -1,4 +1,5 @@
 from math import ceil, sqrt
+from typing import Callable
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -10,7 +11,7 @@ from jaxtyping import Float, Int
 from matplotlib.colors import Normalize
 
 from openretina.modules.layers import regularizers
-from openretina.modules.readout.base import Readout
+from openretina.modules.readout.base import Readout, initialize_bias_from_mean_rate, softplus_inverse
 
 
 class LNPReadout(Readout):
@@ -129,5 +130,15 @@ class LNPReadout(Readout):
         return self.n_neurons
 
     def initialize(self, mean_activity: Float[torch.Tensor, " n_neurons"] | None = None) -> None:
-        if self.inner_product_kernel.bias is not None and mean_activity is not None:
-            self.inner_product_kernel.bias.data = mean_activity
+        bias = self.inner_product_kernel.bias
+        if bias is None or mean_activity is None:
+            return
+
+        if self.nonlinearity is torch.exp:
+            inverse_link: Callable[[torch.Tensor], torch.Tensor] = torch.log
+        elif self.nonlinearity is torch.nn.functional.softplus:
+            inverse_link = softplus_inverse
+        else:
+            # Preserve the previous initialization for links without a known inverse.
+            inverse_link = nn.Identity()
+        initialize_bias_from_mean_rate(bias, mean_activity, inverse_link=inverse_link)

--- a/openretina/modules/readout/spatial_contrast_model_readout.py
+++ b/openretina/modules/readout/spatial_contrast_model_readout.py
@@ -96,7 +96,10 @@ class SpatialContrastReadout(Readout):
         return self.w
 
     def initialize(self, mean_activity: Float[torch.Tensor, " n_neurons"] | None = None) -> None:
-        self.initialize_bias(mean_activity)
+        # This compatibility parameter is not part of the forward pass; the
+        # actual preactivation offset for this readout is ``nl_c``.
+        with torch.no_grad():
+            self.bias.zero_()
 
     def regularizer(self, reduction: Literal["sum", "mean", None] = "sum") -> torch.Tensor:
         """No regularization needed for 4 params per neuron."""


### PR DESCRIPTION
## Goldin lr_scheduler

The goldin lr_scheduler monitors the poison loss and should minimize it, the default is maximizing it.
For the model used in the paper we used the one_cycle_lr, though (in the submitted config it's reduce_lr_on_plateau)

## Bias initialization with mean activity of neurons

Should use softplus^{-1} (bias) instead of just (bias), as it's important to take the activation function into account, too.

Although, this did not seem to give any improvements.
